### PR TITLE
Expose port 7001 for HTTP processor that accepts FHIR bundles

### DIFF
--- a/clinical-ingestion/helm-charts/alvearie-ingestion/values.yaml
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/values.yaml
@@ -61,6 +61,13 @@ nifi:
   enabled: true
   service: 
     type: LoadBalancer
+    processors:
+      enabled: true
+      ports:
+        # Expose the HTTP server for the processor that accepts FHIR bundles
+        - name: fhir-over-http
+          port: 7001
+          targetPort: 7001    
   url: ""
   port: 80
   zookeeper:


### PR DESCRIPTION
This commit exposes a second port on the nifi LB service that accepts
FHIR bundles over HTTP.