### PR TITLE
De-Identification chart and integration

### DIFF
--- a/clinical-ingestion/helm-charts/deid/.helmignore
+++ b/clinical-ingestion/helm-charts/deid/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/clinical-ingestion/helm-charts/deid/Chart.yaml
+++ b/clinical-ingestion/helm-charts/deid/Chart.yaml
@@ -1,0 +1,38 @@
+apiVersion: v2
+name: deid
+description: A Helm Chart to deploy the Alvearie De-Identification service.
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 0.0.1
+
+icon: 
+
+keywords:
+  - ibm  
+  - health records
+  - clinical data
+  - alvearie
+  - deid
+
+home: https://github.com/Alvearie/de-identification
+
+maintainers:  
+  - name: Luis A. Garcia    
+    email: luisg@us.ibm.com    

--- a/clinical-ingestion/helm-charts/deid/README.md
+++ b/clinical-ingestion/helm-charts/deid/README.md
@@ -1,0 +1,57 @@
+# De-Identification Service Helm Chart
+
+## Introduction
+
+This [Helm](https://github.com/kubernetes/helm) chart installs an instance of the [Alvearie De-Identification](https://github.com/Alvearie/de-identification) service in a Kubernetes cluster.
+
+## Pre-Requisites
+
+- Kubernetes cluster 1.10+
+- Helm 3.0.0+
+
+## Installation
+
+### Checkout the Code
+
+Git clone this repository and `cd` into this directory.
+
+```bash
+git clone https://github.com/Alvearie/health-patterns.git
+cd clinical-ingestion/helm-charts/deid
+```
+
+### Install the Chart
+
+Install the helm chart with a release name `deid`:
+
+```bash
+helm install deid .
+```
+
+### Using the Chart
+
+Access your FHIR server at: `http://<external-ip>:8080/api/v1/health`
+
+## Uninstallation
+
+To uninstall/delete the `deid` deployment:
+
+```bash
+helm delete deid
+```
+
+## Configuration
+
+Each requirement is configured with the options provided by that Chart.
+Please consult the relevant charts for their configuration options.
+
+See `values.yaml`.
+
+## Contributing
+
+Feel free to contribute by making a [pull request](https://github.com/Alvearie/health-patterns/pull/new/master).
+
+Please review the [Contributing Guide](https://github.com/Alvearie/health-patterns/blob/main/CONTRIBUTING.md) for information on how to get started contributing to the project.
+
+## License
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) 

--- a/clinical-ingestion/helm-charts/deid/templates/NOTES.txt
+++ b/clinical-ingestion/helm-charts/deid/templates/NOTES.txt
@@ -1,0 +1,16 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "deid.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "deid.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "deid.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo De-Idenetification Service: http://$SERVICE_IP:{{ .Values.service.httpPort }}/api/v1/health
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "deid.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+  echo "De-Identification Service: http://127.0.0.1:8080/api/v1/health"
+{{- end }}
+

--- a/clinical-ingestion/helm-charts/deid/templates/_helpers.tpl
+++ b/clinical-ingestion/helm-charts/deid/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "deid.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "deid.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "deid.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "deid.labels" -}}
+helm.sh/chart: {{ include "deid.chart" . }}
+{{ include "deid.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "deid.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "deid.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "deid.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "deid.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/clinical-ingestion/helm-charts/deid/templates/deployment.yaml
+++ b/clinical-ingestion/helm-charts/deid/templates/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "deid.fullname" . }}
+  labels:
+    {{- include "deid.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "deid.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "deid.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+{{- range $key, $value := .Values.initContainers }}
+        - name: {{ $key }}
+{{ toYaml $value | indent 10 }}
+{{- end }}        
+      containers:
+        - name: service
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/clinical-ingestion/helm-charts/deid/templates/service.yaml
+++ b/clinical-ingestion/helm-charts/deid/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "deid.fullname" . }}
+  labels:
+    {{- include "deid.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: deid-server-http
+  selector:
+    {{- include "deid.selectorLabels" . | nindent 4 }}

--- a/clinical-ingestion/helm-charts/deid/templates/tests/test-connection.yaml
+++ b/clinical-ingestion/helm-charts/deid/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "deid.fullname" . }}-test-connection"
+  labels:
+    {{- include "deid.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "deid.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/clinical-ingestion/helm-charts/deid/values.yaml
+++ b/clinical-ingestion/helm-charts/deid/values.yaml
@@ -1,0 +1,47 @@
+# Default values for fhir.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: atclark/deid
+  pullPolicy: IfNotPresent
+  tag: latest
+service:
+  type: ClusterIP
+  port: 8080
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
This PR adds a new Chart project to deploy an instance of the De-ID
service to a K8S cluster.

The chart deploys the container image created by @ibmatc to run the
de-id service JAR as described in the Alvearie de-id github page.