### PR TITLE
Update notes to the various charts we have created so far

### DIFF
--- a/clinical-ingestion/helm-charts/alvearie-ingestion/de-id-pattern-values.yaml
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/de-id-pattern-values.yaml
@@ -1,3 +1,6 @@
+# A simple name describing the Alvearie pattern implemented by this Helm values file 
+pattern: "De-Identification"
+
 # ------------------------------------------------------------------------------
 # FHIR Configuration
 # Values: https://github.com/Alvearie/health-patterns/clinical-ingestion/helm-charts/fhir/values.yaml

--- a/clinical-ingestion/helm-charts/alvearie-ingestion/templates/NOTES.txt
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/templates/NOTES.txt
@@ -1,0 +1,123 @@
+Welcome to the
+
+       d8888 888                                    d8b          
+      d88888 888                                    Y8P          
+     d88P888 888                                                 
+    d88P 888 888 888  888  .d88b.   8888b.  888d888 888  .d88b.  
+   d88P  888 888 888  888 d8P  Y8b     "88b 888P"   888 d8P  Y8b 
+  d88P   888 888 Y88  88P 88888888 .d888888 888     888 88888888 
+ d8888888888 888  Y8bd8P  Y8b.     888  888 888     888 Y8b.     
+d88P     888 888   Y88P    "Y8888  "Y888888 888     888  "Y8888  
+                                                                 
+                               Clinical Data Ingestion Framework 
+
+Pattern: {{ .Values.pattern }}
+
+The following services have been deployed:
+{{- if .Values.fhir.enabled }}
+- Primary FHIR Server
+{{- end }}
+{{- if index .Values "fhir-deid" "enabled" }}
+- Secondary FHIR Server
+{{- end }}
+{{- if .Values.deid.enabled }}
+- De-Identification Service
+{{- end }}
+{{- if .Values.nifi.enabled }}
+- NiFi Server
+{{- end }}
+{{- if index .Values "nifi-registry" "enabled" }}
+- NiFi Registry
+{{- end }}
+{{- if .Values.kafka.enabled }}
+- Kafka
+{{- end }}
+{{- if .Values.zookeeper.enabled }}
+- Zookeeper
+{{- end }}
+{{- if index .Values "kube-prometheus-stack" "enabled" }}
+- Prometheus
+- Grafana
+{{- end }}
+
+It may take a few minutes for the LoadBalancer IPs to be available.
+
+Watch the status of the public services by running the following command and wait until the external IP addresses appear: 
+
+  kubectl get --namespace {{ .Release.Namespace }} svc -w | grep LoadBalancer
+
+Once the external IPs have been assigned run the following commands to access the corresponding public services.
+
+{{- if .Values.fhir.enabled }}
+
+Primary FHIR Server:
+
+  export FHIR_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ .Release.Name }}-fhir -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+  export FHIR_PORT=$(kubectl get svc {{ .Release.Name }}-fhir -o jsonpath='{.spec.ports[0].port}') 
+  echo Primary FHIR Server: http://$FHIR_IP:$FHIR_PORTfhir-server/api/v4
+
+{{- end }}
+{{- if index .Values "fhir-deid" "enabled" }}
+
+Secondary FHIR Server:
+
+  export FHIR_DEID_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ .Release.Name }}-fhir-deid -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+  export FHIR_DEID_PORT=$(kubectl get svc {{ .Release.Name }}-fhir-deid -o jsonpath='{.spec.ports[0].port}') 
+  echo Secondary FHIR Server: http://$FHIR_DEID_IP:$FHIR_DEID_PORTfhir-server/api/v4
+
+{{- end }}
+{{- if .Values.nifi.enabled }}
+
+NiFi Server:
+
+  export NIFI_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ .Release.Name }}-nifi -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+  export NIFI_PORT=$(kubectl get svc {{ .Release.Name }}-nifi -o jsonpath='{.spec.ports[0].port}') 
+  echo Nifi Server: http://$NIFI_IP:$NIFI_PORT/nifi
+
+{{- end }}
+{{- if .Values.kafka.enabled }}
+
+Kafka Broker:
+
+  export KAFKA_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ .Release.Name }}-kafka-0-external -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+  export KAFKA_PORT=$(kubectl get svc {{ .Release.Name }}-nifi -o jsonpath='{.spec.ports[0].port}') 
+  echo Kafka Broker: $KAFKA_IP:$KAFKA_PORT
+
+{{- end }}
+{{- if index .Values "kube-prometheus-stack" "enabled" }}
+
+Grafana Server:
+ 
+  export GRAFANA_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ .Release.Name }}-grafana -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+  export GRAFANA_PORT=$(kubectl get svc {{ .Release.Name }}-grafana -o jsonpath='{.spec.ports[0].port}') 
+  echo Grafana Server: http://$GRAFANA_IP:$GRAFANA_PORT
+
+{{- end }}
+
+Inside the cluster you can access the services at the following locations:
+
+{{- if .Values.fhir.enabled }}
+- Primary FHIR Server: {{ .Release.Name }}-fhir.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain}} 
+{{- end }}
+{{- if index .Values "fhir-deid" "enabled" }}
+- Secondary FHIR Server: {{ .Release.Name }}-fhir-deid.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain}} 
+{{- end }}
+{{- if .Values.deid.enabled }}
+- De-Identification Service: {{ .Release.Name }}-deid.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain}}
+{{- end }}
+{{- if .Values.nifi.enabled }}
+- NiFi Server: {{ .Release.Name }}-nifi.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain}}
+{{- end }}
+{{- if index .Values "nifi-registry" "enabled" }}
+- NiFi Registry: {{ .Release.Name }}-nifi-registry.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain}}
+{{- end }}
+{{- if .Values.kafka.enabled }}
+- Kafka: {{ .Release.Name }}-kafka.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain}}
+{{- end }}
+{{- if .Values.zookeeper.enabled }}
+- Zookeeper: {{ .Release.Name }}-zookeeper.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain}}
+{{- end }}
+{{- if index .Values "kube-prometheus-stack" "enabled" }}
+- Grafana: {{ .Release.Name }}-grafana.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain}}
+{{- end }}
+

--- a/clinical-ingestion/helm-charts/alvearie-ingestion/values.yaml
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/values.yaml
@@ -5,6 +5,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# A simple name describing the Alvearie pattern implemented by this Helm values file
+pattern: "Ingestion"
+
 nameOverride: ""
 fullnameOverride: ""
 
@@ -50,6 +53,7 @@ fhir-deid:
 # Values: https://github.com/cetic/helm-nifi/blob/master/values.yaml
 # ------------------------------------------------------------------------------
 nifi-registry:
+  enabled: true
   # The fullname is overridden to some static name in order to automatically register the NiFi Registry with the NiFi deployment
   fullnameOverride: ingestion-nifi-registry
 

--- a/clinical-ingestion/helm-charts/deid/templates/NOTES.txt
+++ b/clinical-ingestion/helm-charts/deid/templates/NOTES.txt
@@ -1,16 +1,33 @@
-1. Get the application URL by running these commands:
-{{- if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "deid.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "deid.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "deid.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo De-Idenetification Service: http://$SERVICE_IP:{{ .Values.service.httpPort }}/api/v1/health
-{{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "deid.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
-  echo "De-Identification Service: http://127.0.0.1:8080/api/v1/health"
-{{- end }}
+The De-Identification Services can be accessed from within your cluster at the following location:
 
+  {{ include "deid.fullname" .}}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain}}
+ 
+To connect to your NiFi Registry from outside the cluster, follow the instructions below:
+ 
+Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "deid.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")  
+  echo NiFi Registry: http://$NODE_IP:$NODE_PORT/api/v1/deidentification
+  
+{{- else if contains "LoadBalancer" .Values.service.type }}
+
+It may take a few minutes for the LoadBalancer IP to be available.
+
+You can watch the status by running the following command and wait unti the external IP address appears: 
+
+  kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "deid.fullname" . }}
+
+Once the external IP has been assigned run the following:
+
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "deid.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}') 
+  echo NiFi Registry: http://$SERVICE_IP:{{ .Values.service.Port }}/api/v1/deidentification
+
+{{- else if contains "ClusterIP" .Values.service.type }}
+
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "deid.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo NiFi Registry: http://127.0.0.1:{{ .Values.service.port }}/api/v1/deidentification
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ .Values.service.port }}:{{ .Values.service.port }}
+
+{{- end }}

--- a/clinical-ingestion/helm-charts/fhir/templates/NOTES.txt
+++ b/clinical-ingestion/helm-charts/fhir/templates/NOTES.txt
@@ -1,24 +1,56 @@
-1. Get the application URL by running these commands:
+The IBM FHIR server can be accessed from within your cluster at the following location:
+
+  {{ include "fhir.fullname" .}}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain}}
+ 
+To connect to your IBM FHIR server from outside the cluster, follow the instructions below:
+ 
+Get the application URL by running these commands:
 {{- if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "fhir.fullname" . }})
+
+  export NODE_PORT_HTTP=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "fhir.fullname" . }})
+  export NODE_PORT_HTTPS=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[1].nodePort}" services {{ include "fhir.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
+  echo FHIR Server over HTTP: http://$NODE_IP:$NODE_PORT_HTTP/fhir-server/api/v4
+  echo FHIR Server over HTTPs: https://$NODE_IP:$NODE_PORT_HTTPS/fhir-server/api/v4
+  
 {{- else if contains "LoadBalancer" .Values.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "fhir.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "fhir.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+
+It may take a few minutes for the LoadBalancer IP to be available.
+
+You can watch the status by running the following command and wait unti the external IP address appears: 
+
+  kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "fhir.fullname" . }}
+
+Once the external IP has been assigned run the following:
+
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "fhir.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}') 
   echo FHIR Server over HTTP: http://$SERVICE_IP:{{ .Values.service.httpPort }}/fhir-server/api/v4
   echo FHIR Server over HTTPs: http://$SERVICE_IP:{{ .Values.service.httpsPort }}/fhir-server/api/v4
+
 {{- if .Values.proxy.enabled }}
+
+This chart deployment included creating an unauthenticated FHIR proxy, you can access it at the following location:
+
   echo FHIR Server Proxy: http://$SERVICE_IP:{{ .Values.proxy.service.port }}/fhir-server/api/v4
-{{ end }}
+{{- end }}
+	
 {{- else if contains "ClusterIP" .Values.service.type }}
+
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "fhir.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8081:81
-  echo "FHIR Server: http://127.0.0.1:8080/fhir-server/api/v4"
-{{- if .Values.proxy.enabled }}
-  echo "FHIR Server Proxy: http://127.0.0.1:8081/fhir-server/api/v4"
-{{ end }}
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ .Values.service.httpPort }}:{{ .Values.service.httpPort }}
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ .Values.service.httpsPort }}:{{ .Values.service.httpsPort }}  
+  echo FHIR Server over HTTP: http://127.0.0.1:{{ .Values.service.httpPort }}/fhir-server/api/v4
+  echo FHIR Server over HTTPs: http://127.0.0.1:{{ .Values.service.httpsPort }}/fhir-server/api/v4
+
+  {{- if .Values.proxy.enabled }}
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ .Values.proxy.service.httpPort }}:{{ .Values.proxy.service.httpPort }}
+  echo FHIR Server proxy: http://127.0.0.1:{{ .Values.proxy.service.httpPort }}/fhir-server/api/v4
+  {{- end }}
+  
+
 {{- end }}
 
+To get the credentials to access this FHIR server run the following command:
+
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "fhir.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  kubectl exec $POD_NAME -c server -- cat server.xml | grep -A2 BasicRealm

--- a/clinical-ingestion/helm-charts/fhir/values.yaml
+++ b/clinical-ingestion/helm-charts/fhir/values.yaml
@@ -10,7 +10,7 @@ image:
   tag: 4.5.2
 
 service:
-  type: LoadBalancer
+  type: ClusterIP
   httpPort: 80
   httpsPort: 443
   
@@ -89,7 +89,7 @@ tolerations: []
 
 affinity: {}
 
-env: {}
+env: []
 # Example:
 # - name: FHIR_TRANSACTION_MANAGER_TIMEOUT
 #   value: '300s'

--- a/clinical-ingestion/helm-charts/nifi-registry/templates/NOTES.txt
+++ b/clinical-ingestion/helm-charts/nifi-registry/templates/NOTES.txt
@@ -1,17 +1,33 @@
-1. Get the application URL by running these commands:
-{{- if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "nifi-registry.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "nifi-registry.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "nifi-registry.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo NiFi Registry: http://$SERVICE_IP:{{ .Values.service.port }}/nifi-registry
-{{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "nifi-registry.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8081:81
-  echo "NiFi Registry: http://127.0.0.1:8080/nifi-registry"
-{{- end }}
+The NiFi Registry can be accessed from within your cluster at the following location:
 
+  {{ include "nifi-registry.fullname" .}}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain}}
+ 
+To connect to your NiFi Registry from outside the cluster, follow the instructions below:
+ 
+Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "nifi-registry.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")  
+  echo NiFi Registry: http://$NODE_IP:$NODE_PORT/nifi-registry
+  
+{{- else if contains "LoadBalancer" .Values.service.type }}
+
+It may take a few minutes for the LoadBalancer IP to be available.
+
+You can watch the status by running the following command and wait unti the external IP address appears: 
+
+  kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "nifi-registry.fullname" . }}
+
+Once the external IP has been assigned run the following:
+
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "nifi-registry.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}') 
+  echo NiFi Registry: http://$SERVICE_IP:{{ .Values.service.Port }}/nifi-registry
+
+{{- else if contains "ClusterIP" .Values.service.type }}
+
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "nifi-registry.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo NiFi Registry: http://127.0.0.1:{{ .Values.service.port }}/nifi-registry
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ .Values.service.port }}:{{ .Values.service.port }}
+
+{{- end }}


### PR DESCRIPTION
This commit includes creating or updating the corresponding NOTES.txt
files for all the charts we have created thus far.

The NOTES.txt file are meant to be a quick introduction to a chart
deployer about how to access the chart's service(s).

This is what users will see when they deploy the `alvearie-ingestion` chart (the pattern name and list of services will vary based on the pattern they deploy).

```
Welcome to the

       d8888 888                                    d8b
      d88888 888                                    Y8P
     d88P888 888
    d88P 888 888 888  888  .d88b.   8888b.  888d888 888  .d88b.
   d88P  888 888 888  888 d8P  Y8b     "88b 888P"   888 d8P  Y8b
  d88P   888 888 Y88  88P 88888888 .d888888 888     888 88888888
 d8888888888 888  Y8bd8P  Y8b.     888  888 888     888 Y8b.
d88P     888 888   Y88P    "Y8888  "Y888888 888     888  "Y8888

                               Clinical Data Ingestion Framework

Pattern: De-Identification

The following services have been deployed:
- Primary FHIR Server
- Secondary FHIR Server
- De-Identification Service
- NiFi Server
- NiFi Registry
- Zookeeper
- Prometheus
- Grafana

It may take a few minutes for the LoadBalancer IPs to be available.

Watch the status of the public services by running the following command and wait until the external IP addresses appear:

  kubectl get --namespace dev-operators svc -w | grep LoadBalancer

Once the external IPs have been assigned run the following commands to access the corresponding public services.

Primary FHIR Server:

  export FHIR_IP=$(kubectl get svc --namespace dev-operators ingestion-fhir -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
  export FHIR_PORT=$(kubectl get svc ingestion-fhir -o jsonpath='{.spec.ports[0].port}')
  echo Primary FHIR Server: http://$FHIR_IP:$FHIR_PORTfhir-server/api/v4

Secondary FHIR Server:

  export FHIR_DEID_IP=$(kubectl get svc --namespace dev-operators ingestion-fhir-deid -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
  export FHIR_DEID_PORT=$(kubectl get svc ingestion-fhir-deid -o jsonpath='{.spec.ports[0].port}')
  echo Secondary FHIR Server: http://$FHIR_DEID_IP:$FHIR_DEID_PORTfhir-server/api/v4

NiFi Server:

  export NIFI_IP=$(kubectl get svc --namespace dev-operators ingestion-nifi -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
  export NIFI_PORT=$(kubectl get svc ingestion-nifi -o jsonpath='{.spec.ports[0].port}')
  echo Nifi Server: http://$NIFI_IP:$NIFI_PORT/nifi

Grafana Server:

  export GRAFANA_IP=$(kubectl get svc --namespace dev-operators ingestion-grafana -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
  export GRAFANA_PORT=$(kubectl get svc ingestion-grafana -o jsonpath='{.spec.ports[0].port}')
  echo Grafana Server: http://$GRAFANA_IP:$GRAFANA_PORT

Inside the cluster you can access the services at the following locations:
- Primary FHIR Server: ingestion-fhir.dev-operators.svc.
- Secondary FHIR Server: ingestion-fhir-deid.dev-operators.svc.
- De-Identification Service: ingestion-deid.dev-operators.svc.
- NiFi Server: ingestion-nifi.dev-operators.svc.
- NiFi Registry: ingestion-nifi-registry.dev-operators.svc.
- Zookeeper: ingestion-zookeeper.dev-operators.svc.
- Grafana: ingestion-grafana.dev-operators.svc.
```