### PR TITLE
Update the images from our personal docker hub accounts to alvearie's

### DIFF
--- a/clinical-ingestion/helm-charts/alvearie-ingestion/values.yaml
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/values.yaml
@@ -162,7 +162,7 @@ nifi:
     # The NARs will be copied to a shared volume, and the customLibPath will be set to the location
     # of that shared volume in the main NiFi server container and set in nifi.properties
     alvearie-nars-init:
-      image: luisgarc/alvearie-nars
+      image: alvearie/nars:0.0.1
       imagePullPolicy: Always
       command: ["sh", "-c", "cp *.nar /nars"]
       volumeMounts:

--- a/clinical-ingestion/helm-charts/deid/values.yaml
+++ b/clinical-ingestion/helm-charts/deid/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: atclark/deid
+  repository: alvearie/deid
   pullPolicy: IfNotPresent
   tag: latest
 service:

--- a/clinical-ingestion/helm-charts/fhir/values.yaml
+++ b/clinical-ingestion/helm-charts/fhir/values.yaml
@@ -29,7 +29,7 @@ resources: {}
 proxy:
   enabled: false
   image:
-    repository: luisgarc/fhir-proxy
+    repository: alvearie/fhir-proxy
     pullPolicy: IfNotPresent
     tag: latest
   service:


### PR DESCRIPTION
This commit changes the location of the various container images that we
use in alvarie's ingestion pattern from our personal docker hub accounts
to the official alvearie account.

I have uploaded the images to docker hub under the new account here:

- https://hub.docker.com/repository/docker/alvearie/nars
- https://hub.docker.com/repository/docker/alvearie/fhir-proxy
- https://hub.docker.com/repository/docker/alvearie/deid