### PR TITLE
fix script location to be alvearie

### DIFF
--- a/clinical-ingestion/helm-charts/alvearie-ingestion/values.yaml
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/values.yaml
@@ -39,14 +39,14 @@ fhir:
   env:
     # Per the FHIR team this is recommended to avoid some time out issues seen when deploying recently.
     - name: FHIR_TRANSACTION_MANAGER_TIMEOUT
-      value: '300s' 
+      value: '300s'
 
 fhir-deid:
   enabled: false
   env:
     # Per the FHIR team this is recommended to avoid some time out issues seen when deploying recently.
     - name: FHIR_TRANSACTION_MANAGER_TIMEOUT
-      value: '300s' 
+      value: '300s'
 
 # ------------------------------------------------------------------------------
 # Nifi Registry
@@ -97,7 +97,7 @@ nifi:
         - -c
         - |
           echo "downloading nifi init script..."
-          curl -k --url https://raw.github.ibm.com/integrationsquad/integration-tools/master/scriptex.sh?token=AABLLYCPUJ5BLBIVHRPICI27Z7WVO -o /scripts/initialize-reporting-task.sh
+          curl -k --url https://raw.githubusercontent.com/Alvearie/health-patterns/main/clinical-ingestion/utilities/scriptex.sh -o /scripts/initialize-reporting-task.sh
           echo "done downloading nifi init script"
 
           echo "waiting for NiFi API to start nifi 8080"


### PR DESCRIPTION
The first two changes in this PR are not significant.  They are for whitespace (detected by my editor).  The important change is switching to use the configure script that is now stored on Alvearie.  Originally, while in dev, the script was pushed up to a temporary location on the integration squad github to allow experimenting with the process.  This was fine at the time but I believe there is a possible/probable problem due to the access token expiring.  In addition, it just makes sense that we would use the version on Alvearie to keep it all together.