### PR TITLE
Implement CI Chart install

### DIFF
--- a/.github/workflows/test-charts.yaml
+++ b/.github/workflows/test-charts.yaml
@@ -16,14 +16,15 @@ jobs:
         with:
           version: v3.4.1
 
-      - uses: actions/setup-python@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
         with:
           python-version: 3.7
 
-      - name: Set up chart-testing
+      - name: Set up chart-testing (ct)
         uses: helm/chart-testing-action@v2.0.1
 
-      - name: Run chart-testing (list-changed)
+      - name: Get changed charts (ct list-changed)
         id: list-changed
         run: |
           changed=$(ct list-changed --chart-dirs clinical-ingestion/helm-charts --target-branch main)
@@ -31,12 +32,20 @@ jobs:
             echo "::set-output name=changed::true"
           fi
 
-      - name: Run chart-testing (lint)
+      - name: Lint charts (ct lint)
         run: ct lint --chart-dirs clinical-ingestion/helm-charts --target-branch main --validate-maintainers=false --debug
 
-#      - name: Create kind cluster
-#        uses: helm/kind-action@v1.0.0
-#        if: steps.list-changed.outputs.changed == 'true'
+      - name: Create 'kind' cluster
+        uses: helm/kind-action@v1.0.0
+        if: steps.list-changed.outputs.changed == 'true'
 
-#      - name: Run chart-testing (install)
-#        run: ct install
+      # We need to know the name of the release or be able to set it (the expected release name is 'ingestion' by default)
+      # ct does not allow the option to do that, so we explocitly run the commands that `ct install` would have run
+      - name: Install charts (helm install)
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add cetic https://cetic.github.io/helm-charts
+          helm repo add prometheus https://prometheus-community.github.io/helm-charts
+          helm dependency build clinical-ingestion/helm-charts/alvearie-ingestion
+          helm install ingestion clinical-ingestion/helm-charts/alvearie-ingestion --values clinical-ingestion/helm-charts/alvearie-ingestion/ci/chart-testing-values.yaml --wait --timeout 6m0s
+          kubectl get all

--- a/clinical-ingestion/helm-charts/alvearie-ingestion/Chart.yaml
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/clinical-ingestion/helm-charts/alvearie-ingestion/charts/fhir/values.yaml
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/charts/fhir/values.yaml
@@ -31,7 +31,7 @@ proxy:
   image:
     repository: alvearie/fhir-proxy
     pullPolicy: IfNotPresent
-    tag: latest
+    tag: 0.0.1
   service:
     port: 81
   resources: {}

--- a/clinical-ingestion/helm-charts/alvearie-ingestion/ci/chart-testing-values.yaml
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/ci/chart-testing-values.yaml
@@ -1,0 +1,51 @@
+# A simple name describing the Alvearie pattern implemented by this Helm values file
+pattern: "Chart Test"
+
+# ------------------------------------------------------------------------------
+# FHIR Configuration
+# Values: https://github.com/Alvearie/health-patterns/clinical-ingestion/helm-charts/fhir/values.yaml
+# ------------------------------------------------------------------------------
+fhir:
+  proxy:
+    enabled: true
+
+# ------------------------------------------------------------------------------
+# FHIR Configuration
+# Values: https://github.com/Alvearie/health-patterns/clinical-ingestion/helm-charts/fhir/values.yaml
+# ------------------------------------------------------------------------------
+fhir-deid:
+  enabled: true
+
+# ------------------------------------------------------------------------------
+# De-Identification Service
+# Values: https://github.com/Alvearie/health-patterns/clinical-ingestion/helm-charts/deid/values.yaml
+# ------------------------------------------------------------------------------
+deid:
+  enabled: true
+
+# ------------------------------------------------------------------------------
+# Nifi Configuration
+# Values: https://github.com/cetic/helm-nifi/blob/master/values.yaml
+# ------------------------------------------------------------------------------
+nifi:
+  service:
+    type: NodePort
+
+# ------------------------------------------------------------------------------
+# Kafka Configuration
+# Values: https://github.com/bitnami/charts/blob/master/bitnami/kafka/values.yaml
+# ------------------------------------------------------------------------------
+kafka:
+  externalAccess:
+    service:
+      type: NodePort
+  metrics:
+    kafka:
+      enabled: false
+
+# ------------------------------------------------------------------------------
+# Kube-Prometheus Stack Configuration
+# Values: https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml
+# ------------------------------------------------------------------------------
+kube-prometheus-stack:
+  enabled: false

--- a/clinical-ingestion/helm-charts/alvearie-ingestion/values.yaml
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/values.yaml
@@ -76,7 +76,7 @@ nifi:
   fullnameOverride: ingestion-nifi
   enabled: true
   service:
-    type: LoadBalancer
+    type: NodePort
     processors:
       enabled: true
       ports:
@@ -190,7 +190,7 @@ kafka:
   externalAccess:
     enabled: true
     service:
-      type: LoadBalancer
+      type: NodePort
       port: 9094
     autoDiscovery:
       enabled: true
@@ -213,7 +213,7 @@ kafka:
     ## Prometheus Kafka Exporter: exposes complimentary metrics to JMX Exporter
     ##
     kafka:
-      enabled: true
+      enabled: false
     ## Prometheus JMX Exporter: exposes the majority of Kafkas metrics
     ## https://github.com/bitnami/charts/blob/master/bitnami/kafka/values.yaml
     jmx:
@@ -245,11 +245,11 @@ deid:
 # on the port defined.  Note there are two kafka type metrics
 # ------------------------------------------------------------------------------
 kube-prometheus-stack:
-  enabled: true
+  enabled: false
   grafana:
     adminPassword: admin
     service:
-      type: LoadBalancer
+      type: NodePort
 
     defaultDashboardsEnabled: false
 


### PR DESCRIPTION
This commit enhances the existing charts CI pipeline to include
installing the chart in addition to just linting the charts.

The installation is done in a `kind` kubernetes cluster that is setup as
part of the Github Action.

A new `*-values.yaml` file is added that has the configuration necessary
to install the chart for testing purposes. That includes disabling
certain components that are not supported by the `kind` cluster such as
the prometheus stack and using `LoadBalancer` services.

This test values.yaml also includes installing the de-id service and the
FHIR Proxy for better coverage.

Also, provide a specific FHIR Proxy container image version.