### PR TITLE
Fix deid deployment version

### DIFF
--- a/clinical-ingestion/helm-charts/alvearie-ingestion/Chart.yaml
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/clinical-ingestion/helm-charts/alvearie-ingestion/charts/deid/values.yaml
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/charts/deid/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: alvearie/deid
   pullPolicy: IfNotPresent
-  tag: latest
+  tag: 0.0.1
 service:
   type: ClusterIP
   port: 8080


### PR DESCRIPTION
The "latest" tag is not applied to the current container build out in the alvearie docker repo. Switched to 0.0.1 to reflect the current/only version.  Probably preferable to "latest" anyway so we don't get unexpected changes to behavior. 