### PR TITLE
Disablemonitoring

### DIFF
--- a/clinical-ingestion/helm-charts/alvearie-ingestion/Chart.yaml
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/clinical-ingestion/helm-charts/alvearie-ingestion/README.md
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/README.md
@@ -61,7 +61,7 @@ To uninstall/delete the `ingestion` deployment:
 helm delete ingestion
 ```
 
-Deletion of charts doesn't cascade to deleting associated `PersistedVolume`s and `PersistedVolumeClains`s. 
+Deletion of charts doesn't cascade to deleting associated `PersistedVolume`s and `PersistedVolumeClaims`s.
 To delete them:
 
 ```bash
@@ -82,6 +82,19 @@ Please consult the relevant charts for their configuration options.
 | `fhir.enabled`           | Enable [Spark](../fhir)                                                                                            | `true`    |
 | `zookeeper.enabled`      | Enable [Zookeeper](https://github.com/bitnami/charts/tree/master/bitnami/zookeeper)                                | `true`    |
 
+## Monitoring
+
+There is a grafana-based monitoring solution that has been included as part of this chart.  It is disabled by default in the chart, however, it can be enabled by setting the following options to `true` (note that they are currently all set to `false`).
+
+```bash
+kafka.metrics.kafka.enabled
+kafka.metrics.jmx.enabled
+kafka.metrics.serviceMonitor.enabled
+kube-prometheus-stack.enabled
+```
+
+It is important to note that due to a limitation in grafana that causes multi-install collisions, only one instance of the chart should be installed when the monitoring solution is turned on.
+
 ## Contributing
 
 Feel free to contribute by making a [pull request](https://github.com/Alvearie/health-patterns/pull/new/master).
@@ -89,4 +102,4 @@ Feel free to contribute by making a [pull request](https://github.com/Alvearie/h
 Please review the [Contributing Guide](https://github.com/Alvearie/health-patterns/blob/main/CONTRIBUTING.md) for information on how to get started contributing to the project.
 
 ## License
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/clinical-ingestion/helm-charts/alvearie-ingestion/values.yaml
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/values.yaml
@@ -213,14 +213,14 @@ kafka:
     ## Prometheus Kafka Exporter: exposes complimentary metrics to JMX Exporter
     ##
     kafka:
-      enabled: true
+      enabled: false
     ## Prometheus JMX Exporter: exposes the majority of Kafkas metrics
     ## https://github.com/bitnami/charts/blob/master/bitnami/kafka/values.yaml
     jmx:
-      enabled: true
+      enabled: false
 
     serviceMonitor:
-      enabled: true
+      enabled: false
 
 # ------------------------------------------------------------------------------
 # De-Identification Service
@@ -245,7 +245,7 @@ deid:
 # on the port defined.  Note there are two kafka type metrics
 # ------------------------------------------------------------------------------
 kube-prometheus-stack:
-  enabled: true
+  enabled: false
   grafana:
     adminPassword: admin
     service:


### PR DESCRIPTION
After our investigation we have decided to disable the monitoring solution by default and allow users to enable it if they wish.  This PR sets the proper enabled flags to false and provides documentation as to the necessary changes that need to be made to enable in the future.