### PR TITLE
Revert intermediate test changes to values.yaml

### DIFF
--- a/clinical-ingestion/helm-charts/alvearie-ingestion/Chart.yaml
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/clinical-ingestion/helm-charts/alvearie-ingestion/ci/chart-testing-values.yaml
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/ci/chart-testing-values.yaml
@@ -49,3 +49,7 @@ kafka:
 # ------------------------------------------------------------------------------
 kube-prometheus-stack:
   enabled: false
+
+metrics:
+  kafka:
+    enabled: false

--- a/clinical-ingestion/helm-charts/alvearie-ingestion/values.yaml
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/values.yaml
@@ -76,7 +76,7 @@ nifi:
   fullnameOverride: ingestion-nifi
   enabled: true
   service:
-    type: NodePort
+    type: LoadBalancer
     processors:
       enabled: true
       ports:
@@ -190,7 +190,7 @@ kafka:
   externalAccess:
     enabled: true
     service:
-      type: NodePort
+      type: LoadBalancer
       port: 9094
     autoDiscovery:
       enabled: true
@@ -213,7 +213,7 @@ kafka:
     ## Prometheus Kafka Exporter: exposes complimentary metrics to JMX Exporter
     ##
     kafka:
-      enabled: false
+      enabled: true
     ## Prometheus JMX Exporter: exposes the majority of Kafkas metrics
     ## https://github.com/bitnami/charts/blob/master/bitnami/kafka/values.yaml
     jmx:
@@ -245,11 +245,11 @@ deid:
 # on the port defined.  Note there are two kafka type metrics
 # ------------------------------------------------------------------------------
 kube-prometheus-stack:
-  enabled: false
+  enabled: true
   grafana:
     adminPassword: admin
     service:
-      type: NodePort
+      type: LoadBalancer
 
     defaultDashboardsEnabled: false
 


### PR DESCRIPTION
Change the values.yaml back to what it was before the chart install
phase was added. Those values should be in the
`chart-testing-values.yaml` but are not part of the default
`values.yaml`