### PR TITLE
Add Cohort Service sub-chart to Clinical Ingestion Chart

### DIFF
--- a/clinical-ingestion/helm-charts/alvearie-ingestion/Chart.yaml
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.4
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -54,6 +54,10 @@ dependencies:
     version: 0.1.0
     condition: deid.enabled
     repository: ""
+  - name: cohort-service
+    version: 0.0.1
+    repository: ""
+    condition: cohort-service.enabled
   - name: nifi-registry
     version: 0.1.0
     condition: nifi-registry.enabled

--- a/clinical-ingestion/helm-charts/alvearie-ingestion/charts/cohort-service/Chart.yaml
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/charts/cohort-service/Chart.yaml
@@ -1,0 +1,35 @@
+apiVersion: v2
+name: cohort-service
+description: A Helm Chart to deploy the Alvearie Health Patterns Cohort Service App.
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.0.0
+
+keywords:
+  - ibm
+  - health records
+  - clinical data
+  - alvearie
+
+home: https://github.com/Alvearie/health-patterns/clinical-ingestion/cohort-service
+
+maintainers:
+  - name: Luis A. Garcia
+    email: luisg@us.ibm.com

--- a/clinical-ingestion/helm-charts/alvearie-ingestion/charts/cohort-service/templates/NOTES.txt
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/charts/cohort-service/templates/NOTES.txt
@@ -1,0 +1,33 @@
+The Alvearie Cohort Service can be accessed from within your cluster at the following location:
+
+  {{ include "cohort-service.fullname" .}}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain}}
+ 
+To connect to your Alvearie cohort-service server from outside the cluster, follow the instructions below:
+ 
+Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+
+  export NODE_PORT_HTTP=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "cohort-service.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo cohort-service Server over HTTP: http://$NODE_IP:$NODE_PORT_HTTP/cohort-service/health
+  
+{{- else if contains "LoadBalancer" .Values.service.type }}
+
+It may take a few minutes for the LoadBalancer IP to be available.
+
+You can watch the status by running the following command and wait unti the external IP address appears: 
+
+  kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "cohort-service.fullname" . }}
+
+Once the external IP has been assigned run the following:
+
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "cohort-service.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}') 
+  echo cohort-service Server over HTTP: http://$SERVICE_IP:{{ .Values.service.httpPort }}/cohort-service/health
+
+{{- else if contains "ClusterIP" .Values.service.type }}
+
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "cohort-service.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ .Values.service.httpPort }}:{{ .Values.service.httpPort }}
+  echo cohort-service Server over HTTP: http://127.0.0.1:{{ .Values.service.httpPort }}/cohort-service/health
+
+{{- end }}

--- a/clinical-ingestion/helm-charts/alvearie-ingestion/charts/cohort-service/templates/_helpers.tpl
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/charts/cohort-service/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cohort-service.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cohort-service.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cohort-service.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cohort-service.labels" -}}
+helm.sh/chart: {{ include "cohort-service.chart" . }}
+{{ include "cohort-service.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cohort-service.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cohort-service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cohort-service.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "cohort-service.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/clinical-ingestion/helm-charts/alvearie-ingestion/charts/cohort-service/templates/deployment.yaml
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/charts/cohort-service/templates/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cohort-service.fullname" . }}
+  labels:
+    {{- include "cohort-service.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "cohort-service.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "cohort-service.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+{{- range $key, $value := .Values.initContainers }}
+        - name: {{ $key }}
+{{ toYaml $value | indent 10 }}
+{{- end }}        
+      containers:
+        - name: cohort-service
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/clinical-ingestion/helm-charts/alvearie-ingestion/charts/cohort-service/templates/service.yaml
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/charts/cohort-service/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "fhir.fullname" . }}
+  labels:
+    {{- include "fhir.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.httpPort }}
+      targetPort: http
+      protocol: TCP
+      name: cohort-service-http
+  selector:
+    {{- include "fhir.selectorLabels" . | nindent 4 }}

--- a/clinical-ingestion/helm-charts/alvearie-ingestion/charts/cohort-service/values.yaml
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/charts/cohort-service/values.yaml
@@ -1,0 +1,67 @@
+# Default values for fhir.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: alvearie/cohort-service
+  pullPolicy: IfNotPresent
+  tag: 1.0.0
+
+service:
+  type: LoadBalancer
+  httpPort: 80
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+initContainers:
+  # cohort-service-init:  # <- will be used as container name
+  #  image: "busybox:1.30.1"
+  #  imagePullPolicy: "IfNotPresent"
+  #  command: ['sh', '-c', 'echo this is an initContainer']
+  #    volumeMounts:
+  #    - mountPath: /tmp/foo
+  #      name: foo
+
+extraVolumeMounts: []
+
+extraVolumes: []
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+env: []
+# Example:
+# - name: SOME_VARIABLE
+#   value: some-value

--- a/clinical-ingestion/helm-charts/alvearie-ingestion/ci/chart-testing-values.yaml
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/ci/chart-testing-values.yaml
@@ -6,6 +6,8 @@ pattern: "Chart Test"
 # Values: https://github.com/Alvearie/health-patterns/clinical-ingestion/helm-charts/fhir/values.yaml
 # ------------------------------------------------------------------------------
 fhir:
+  service:
+    type: NodePort
   proxy:
     enabled: true
 
@@ -53,3 +55,12 @@ kube-prometheus-stack:
 metrics:
   kafka:
     enabled: false
+
+# ------------------------------------------------------------------------------
+# Cohort Service
+# Values: https://github.com/Alvearie/health-patterns/cohort-service/chart/values.yaml
+# ------------------------------------------------------------------------------
+cohort-service:
+  enabled: true
+  service:
+    type: NodePort

--- a/clinical-ingestion/helm-charts/alvearie-ingestion/templates/NOTES.txt
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/templates/NOTES.txt
@@ -39,6 +39,9 @@ The following services have been deployed:
 - Prometheus
 - Grafana
 {{- end }}
+{{- if index .Values "cohort-service" "enabled" }}
+- Cohort Service
+{{- end }}
 
 It may take a few minutes for the LoadBalancer IPs to be available.
 
@@ -93,6 +96,16 @@ Grafana Server:
   echo Grafana Server: http://$GRAFANA_IP:$GRAFANA_PORT
 
 {{- end }}
+{{- if index .Values "cohort-service" "enabled" }}
+
+Cohort Service:
+ 
+  export COHORT_SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ .Release.Name }}-cohort-service -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+  export COHORT_SERVICE_PORT=$(kubectl get svc {{ .Release.Name }}-cohort-service -o jsonpath='{.spec.ports[0].port}') 
+  echo Grafana Server: http://$COHORT_SERVICE_IP:$COHORT_SERVICE_PORT
+
+{{- end }}
+
 
 Inside the cluster you can access the services at the following locations:
 
@@ -119,5 +132,8 @@ Inside the cluster you can access the services at the following locations:
 {{- end }}
 {{- if index .Values "kube-prometheus-stack" "enabled" }}
 - Grafana: {{ .Release.Name }}-grafana.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain}}
+{{- end }}
+{{- if index .Values "cohort-service" "enabled" }}
+- Cohort Service: {{ .Release.Name }}-cohort-service.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain}}
 {{- end }}
 

--- a/clinical-ingestion/helm-charts/alvearie-ingestion/values.yaml
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/values.yaml
@@ -36,6 +36,8 @@ affinity: {}
 # ------------------------------------------------------------------------------
 fhir:
   enabled: true
+  service:
+    type: LoadBalancer
   env:
     # Per the FHIR team this is recommended to avoid some time out issues seen when deploying recently.
     - name: FHIR_TRANSACTION_MANAGER_TIMEOUT
@@ -227,6 +229,13 @@ kafka:
 # Values: https://github.com/Alvearie/health-patterns/clinical-ingestion/helm-charts/deid/values.yaml
 # ------------------------------------------------------------------------------
 deid:
+  enabled: false
+
+# ------------------------------------------------------------------------------
+# Cohort Service
+# Values: https://github.com/Alvearie/health-patterns/cohort-service/chart/values.yaml
+# ------------------------------------------------------------------------------
+cohort-service:
   enabled: false
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This commit adds the Cohort Service's chart as a sub-chart of the
Clinical Ingestion main chart. This allows users to try out the cohort
service if needed. By default the service is disabled.

This commit also enabled the `LoadBalancer` for the FHIR service by
default per a discussion in slack about why we had turned it to
`ClusterIP`, which may have been accidentally.

Since we added a new service I bumped the chart version a whole point :)

After this commit the ingestion framework may include the cohort service
as shown below:

```
Welcome to the

       d8888 888                                    d8b
      d88888 888                                    Y8P
     d88P888 888
    d88P 888 888 888  888  .d88b.   8888b.  888d888 888  .d88b.
   d88P  888 888 888  888 d8P  Y8b     "88b 888P"   888 d8P  Y8b
  d88P   888 888 Y88  88P 88888888 .d888888 888     888 88888888
 d8888888888 888  Y8bd8P  Y8b.     888  888 888     888 Y8b.
d88P     888 888   Y88P    "Y8888  "Y888888 888     888  "Y8888

                               Clinical Data Ingestion Framework

Pattern: Ingestion

The following services have been deployed:
- Primary FHIR Server
- NiFi Server
- NiFi Registry
- Zookeeper
- Cohort Service  <--- New
```