### PR TITLE
Refactor Common Component with base FHIR Service

### DIFF
--- a/nifi-processors/nifi-health-patterns-bundle/nifi-health-patterns-processors/src/main/java/com/ibm/healthpatterns/processors/common/FHIRServiceCustomProcessor.java
+++ b/nifi-processors/nifi-health-patterns-bundle/nifi-health-patterns-processors/src/main/java/com/ibm/healthpatterns/processors/common/FHIRServiceCustomProcessor.java
@@ -16,32 +16,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.ibm.healthpatterns.deid;
+package com.ibm.healthpatterns.processors.common;
 
-import com.ibm.healthpatterns.core.FHIRServiceException;
+import com.ibm.healthpatterns.core.FHIRService;
 
 /**
+ * An custom processor that will use a {@link FHIRService}.
+ * 
  * @author Luis A. García
  */
-public class DeIdentifierException extends FHIRServiceException {
+public interface FHIRServiceCustomProcessor {
 
 	/**
-	 * 
+	 * @return the {@link FHIRService} used by this {@link FHIRService}
 	 */
-	private static final long serialVersionUID = -2447683821098809222L;
-
-	/**
-	 * @param msg
-	 */
-	public DeIdentifierException(String msg) {
-		super(msg);
-	}
-
-	/**
-	 * @param msg 
-	 * @param cause 
-	 */
-	public DeIdentifierException(String msg, Exception cause) {
-		super(msg, cause);
-	}
+	public FHIRService getFHIRService();
 }

--- a/nifi-processors/nifi-health-patterns-bundle/nifi-health-patterns-processors/src/main/java/com/ibm/healthpatterns/processors/deid/DeIdentifyAndPostToFHIR.java
+++ b/nifi-processors/nifi-health-patterns-bundle/nifi-health-patterns-processors/src/main/java/com/ibm/healthpatterns/processors/deid/DeIdentifyAndPostToFHIR.java
@@ -61,9 +61,11 @@ import org.apache.nifi.util.FormatUtils;
 import org.apache.nifi.util.StopWatch;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.ibm.healthpatterns.core.FHIRService;
 import com.ibm.healthpatterns.deid.DeIdentification;
 import com.ibm.healthpatterns.deid.DeIdentifier;
 import com.ibm.healthpatterns.deid.DeIdentifierException;
+import com.ibm.healthpatterns.processors.common.FHIRServiceCustomProcessor;
 
 /**
  * Custom processor to deidentify a FHIR resource and save it to a FHIR server.
@@ -76,7 +78,7 @@ import com.ibm.healthpatterns.deid.DeIdentifierException;
 @WritesAttributes({
 	@WritesAttribute(attribute = DeIdentifyAndPostToFHIR.LOCATION_ATTRIBUTE, description = "The HTTP Location header returned by the FHIR server when a resource is created"),
 	@WritesAttribute(attribute = DeIdentifyAndPostToFHIR.DEID_TRANSACTION_ID_ATTRIBUTE , description = "All FlowFiles produced from the deidentifying and persisting the same parent FlowFile will have the same randomly generated UUID added for this attribute")})
-public class DeIdentifyAndPostToFHIR extends AbstractProcessor {
+public class DeIdentifyAndPostToFHIR extends AbstractProcessor implements FHIRServiceCustomProcessor {
 
 	/**
 	 * The MIME Type attribute
@@ -324,7 +326,15 @@ public class DeIdentifyAndPostToFHIR extends AbstractProcessor {
 	/**
 	 * @return the deidentifiers used by this custom processor
 	 */
-	DeIdentifier getDeidentifier() {
+	public DeIdentifier getDeidentifier() {
 		return deid;
+	}
+
+	/* (non-Javadoc)
+	 * @see com.ibm.healthpatterns.processors.common.FHIRServiceCustomProcessor#getFHIRService()
+	 */
+	@Override
+	public FHIRService getFHIRService() {
+		return getDeidentifier();
 	}
 }

--- a/nifi-processors/nifi-health-patterns-bundle/nifi-health-patterns-processors/src/main/java/com/ibm/healthpatterns/processors/terminology/FHIRConceptMapTranslate.java
+++ b/nifi-processors/nifi-health-patterns-bundle/nifi-health-patterns-processors/src/main/java/com/ibm/healthpatterns/processors/terminology/FHIRConceptMapTranslate.java
@@ -57,6 +57,8 @@ import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.util.FormatUtils;
 import org.apache.nifi.util.StopWatch;
 
+import com.ibm.healthpatterns.core.FHIRService;
+import com.ibm.healthpatterns.processors.common.FHIRServiceCustomProcessor;
 import com.ibm.healthpatterns.terminology.TerminologyService;
 import com.ibm.healthpatterns.terminology.TerminologyServiceException;
 import com.ibm.healthpatterns.terminology.Translation;
@@ -71,7 +73,7 @@ import com.ibm.healthpatterns.terminology.Translation;
 @InputRequirement(Requirement.INPUT_REQUIRED)
 @WritesAttributes({
 	@WritesAttribute(attribute = FHIRConceptMapTranslate.TRANSLATED_ATTRIBUTE, description = "A boolean property that will get set to true when a translation occurred.")})
-public class FHIRConceptMapTranslate extends AbstractProcessor {
+public class FHIRConceptMapTranslate extends AbstractProcessor implements FHIRServiceCustomProcessor {
 
 	/**
 	 * A boolean attribute that gets set with translation status.
@@ -247,5 +249,13 @@ public class FHIRConceptMapTranslate extends AbstractProcessor {
 	 */
 	TerminologyService getTerminologyService() {
 		return terminologyService;
+	}
+
+	/* (non-Javadoc)
+	 * @see com.ibm.healthpatterns.processors.common.FHIRServiceCustomProcessor#getFHIRService()
+	 */
+	@Override
+	public FHIRService getFHIRService() {
+		return getTerminologyService();
 	}
 }

--- a/nifi-processors/nifi-health-patterns-bundle/nifi-health-patterns-processors/src/test/java/com/ibm/healthpatterns/processors/common/FHIRCustomProcessorTest.java
+++ b/nifi-processors/nifi-health-patterns-bundle/nifi-health-patterns-processors/src/test/java/com/ibm/healthpatterns/processors/common/FHIRCustomProcessorTest.java
@@ -1,0 +1,86 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.healthpatterns.processors.common;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.nifi.util.TestRunner;
+import org.junit.After;
+
+/**
+ * @author Luis A. García
+ */
+public abstract class FHIRCustomProcessorTest {
+
+	protected TestRunner testRunner;
+	
+	protected String fhirURL;
+	protected String fhirUsername;
+	protected String fhirPassword;
+	
+	protected List<String> createdResources;
+
+	/**
+	 * 
+	 */
+	public FHIRCustomProcessorTest() {
+		// This URL is for IBM Cloud services that we setup specifically to run these tests
+		fhirURL = "http://4603f72b-us-south.lb.appdomain.cloud/fhir-server/api/v4";
+		fhirUsername = "fhiruser";
+		fhirPassword = "integrati0n";
+		createdResources = new ArrayList<>();
+	}
+	
+	/**
+	 * Clean up the FHIR resources created by this test.
+	 * <p>
+	 * The URIs saved by the test cases can be of the form:
+	 * - http://server/fhir-server/api/v4/{ResourceType}/{id}/_history/{version}
+	 * - http://server/fhir-server/api/v4/{ResourceType}/{id}
+	 */
+	@After
+	public void cleanUpFHIR() {
+		for (String uri : createdResources) {
+			String[] uriElements = uri.split("/");
+			String id;
+			String type;
+			if (uri.contains("_history")) {
+				id = uriElements[uriElements.length - 3];
+				type = uriElements[uriElements.length - 4];
+			} else {
+				id = uriElements[uriElements.length - 1];
+				type = uriElements[uriElements.length - 2];
+			}
+			System.out.println("Deleting " + type + " resource " + id);
+			getCustomProcessor().getFHIRService()
+				.getFhirClient()
+				.delete()
+				.resourceById(type, id)
+				.execute();
+		}
+		System.out.println("------------------");
+		System.out.println();    	
+	}
+
+	/**
+	 * @return the {@link FHIRServiceCustomProcessor} used by this test
+	 */
+	public abstract FHIRServiceCustomProcessor getCustomProcessor();
+}

--- a/nifi-processors/nifi-health-patterns-bundle/nifi-health-patterns-processors/src/test/java/com/ibm/healthpatterns/processors/deid/DeIdentifyAndPostToFHIRTest.java
+++ b/nifi-processors/nifi-health-patterns-bundle/nifi-health-patterns-processors/src/test/java/com/ibm/healthpatterns/processors/deid/DeIdentifyAndPostToFHIRTest.java
@@ -22,18 +22,17 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.nifi.util.MockFlowFile;
-import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ibm.healthpatterns.processors.common.FHIRCustomProcessorTest;
+import com.ibm.healthpatterns.processors.common.FHIRServiceCustomProcessor;
 
 /**
  * This test runs the custom process against a real de-id service and FHIR server dedicated 
@@ -44,29 +43,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * 
  * @author Luis A. García
  */
-public class DeIdentifyAndPostToFHIRTest {
-
-	private TestRunner testRunner;
+public class DeIdentifyAndPostToFHIRTest extends FHIRCustomProcessorTest {
 
 	private String deidURL;
-	private String fhirURL;
-	private String fhirUsername;
-	private String fhirPassword;
-
-	private List<String> createdResources;
-
 	private DeIdentifyAndPostToFHIR customProcessor;
-
+	
 	/**
 	 * 
 	 */
 	public DeIdentifyAndPostToFHIRTest() {
-		// These URLs are for two IBM Cloud services that we setup specifically to run these tests 
+		// This URL is for IBM Cloud services that we setup specifically to run these tests 
 		deidURL = "http://3a5d0fa4-us-south.lb.appdomain.cloud:8080/api/v1";
-		fhirURL = "http://4603f72b-us-south.lb.appdomain.cloud/fhir-server/api/v4";
-		fhirUsername = "fhiruser";
-		fhirPassword = "integrati0n";
-		createdResources = new ArrayList<String>();
 	}
 
 	/**
@@ -77,27 +64,6 @@ public class DeIdentifyAndPostToFHIRTest {
 	public void init() throws IOException {
 		customProcessor = new DeIdentifyAndPostToFHIR();
 		testRunner = TestRunners.newTestRunner(customProcessor);
-	}
-
-	/**
-	 * @throws IOException 
-	 * 
-	 */
-	@After
-	public void cleanUpFHIR() throws IOException {
-		for (String uri : createdResources) {
-			String[] uriElements = uri.split("/");
-			String id = uriElements[uriElements.length - 3];
-			String type = uriElements[uriElements.length - 4];
-			System.out.println("Deleting " + type + " resource " + id);
-			customProcessor.getDeidentifier()
-			.getFhirClient()
-			.delete()
-			.resourceById(type, id)
-			.execute();
-		}
-		System.out.println("------------------");
-		System.out.println();    	
 	}
 
 	/**
@@ -204,4 +170,11 @@ public class DeIdentifyAndPostToFHIRTest {
 		testRunner.assertNotValid();
 	}
 
+	/* (non-Javadoc)
+	 * @see com.ibm.healthpatterns.processors.deid.FHIRCustomProcessorTest#getCustomProcessor()
+	 */
+	@Override
+	public FHIRServiceCustomProcessor getCustomProcessor() {
+		return customProcessor;
+	}
 }

--- a/nifi-processors/nifi-health-patterns-bundle/nifi-health-patterns-processors/src/test/java/com/ibm/healthpatterns/processors/terminology/FHIRConceptMapTranslateTest.java
+++ b/nifi-processors/nifi-health-patterns-bundle/nifi-health-patterns-processors/src/test/java/com/ibm/healthpatterns/processors/terminology/FHIRConceptMapTranslateTest.java
@@ -23,18 +23,17 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ibm.healthpatterns.processors.common.FHIRCustomProcessorTest;
+import com.ibm.healthpatterns.processors.common.FHIRServiceCustomProcessor;
 
 /**
  * This test runs the custom process against a real FHIR server dedicated to ensure the functionality here works.
@@ -44,28 +43,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * 
  * @author Luis A. García
  */
-public class FHIRConceptMapTranslateTest {
+public class FHIRConceptMapTranslateTest extends FHIRCustomProcessorTest {
 
 	private TestRunner testRunner;
 
-	private String fhirURL;
-	private String fhirUsername;
-	private String fhirPassword;
-
-	private List<String> createdResources;
-
 	private FHIRConceptMapTranslate customProcessor;
-
-	/**
-	 * 
-	 */
-	public FHIRConceptMapTranslateTest() {
-		// These URLs are for two IBM Cloud services that we setup specifically to run these tests 
-		fhirURL = "http://4603f72b-us-south.lb.appdomain.cloud/fhir-server/api/v4";
-		fhirUsername = "fhiruser";
-		fhirPassword = "integrati0n";
-		createdResources = new ArrayList<String>();
-	}
 
 	/**
 	 * @throws IOException 
@@ -75,27 +57,6 @@ public class FHIRConceptMapTranslateTest {
 	public void init() throws IOException {
 		customProcessor = new FHIRConceptMapTranslate();
 		testRunner = TestRunners.newTestRunner(customProcessor);
-	}
-
-	/**
-	 * @throws IOException 
-	 * 
-	 */
-	@After
-	public void cleanUpFHIR() throws IOException {
-		for (String uri : createdResources) {
-			String[] uriElements = uri.split("/");
-			String id = uriElements[uriElements.length - 1];
-			String type = uriElements[uriElements.length - 2];
-			System.out.println("Deleting " + type + " resource " + id);
-			customProcessor.getTerminologyService()
-				.getFhirClient()
-				.delete()
-				.resourceById(type, id)
-				.execute();
-		}
-		System.out.println("------------------");
-		System.out.println();    	
 	}
 
 	/**
@@ -217,6 +178,14 @@ public class FHIRConceptMapTranslateTest {
 		testRunner.setProperty(FHIRConceptMapTranslate.FHIR_USERNAME, fhirUsername);
 		testRunner.setProperty(FHIRConceptMapTranslate.FHIR_PASSWORD, fhirPassword);
 		testRunner.assertValid();
+	}
+
+	/* (non-Javadoc)
+	 * @see com.ibm.healthpatterns.processors.common.FHIRCustomProcessorTest#getCustomProcessor()
+	 */
+	@Override
+	public FHIRServiceCustomProcessor getCustomProcessor() {
+		return customProcessor;
 	}
 
 }

--- a/services/common/.gitignore
+++ b/services/common/.gitignore
@@ -1,0 +1,16 @@
+/target
+/.m2
+
+
+/.classpath
+/.project
+/.settings
+
+/caches
+/local.properties
+.*.swp
+.DS_Store
+/src/main/resources/application-local.properties
+
+src/main/resources/application-local.properties
+src/main/resources/localdev-config.json

--- a/services/common/LICENSE
+++ b/services/common/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/services/common/README.md
+++ b/services/common/README.md
@@ -1,0 +1,29 @@
+<p align="center">
+    <a href="https://github.com/Alvearie">
+        <img src="https://avatars.githubusercontent.com/u/72946463?s=200&v=4" height="100" alt="Alvearie">
+    </a>
+</p>
+
+
+<p align="center">
+    <a href="https://www.ibm.com/developerworks/learn/java/">
+    <img src="https://img.shields.io/badge/platform-java-lightgrey.svg?style=flat" alt="platform">
+    </a>
+    <img src="https://img.shields.io/badge/license-Apache2-blue.svg?style=flat" alt="Apache 2">
+</p>
+
+
+# Common Component
+
+Some common classes used by the other Health Pattern Services.
+
+
+## Building
+
+See instructions in parent.
+
+## License
+
+This application is licensed under the Apache License, Version 2. Separate third-party code objects invoked within this code pattern are licensed by their respective providers pursuant to their own separate licenses. Contributions are subject to the [Developer Certificate of Origin, Version 1.1](https://developercertificate.org/) and the [Apache License, Version 2](https://www.apache.org/licenses/LICENSE-2.0.txt).
+
+[Apache License FAQ](https://www.apache.org/foundation/license-faq.html#WhatDoesItMEAN)

--- a/services/common/pom.xml
+++ b/services/common/pom.xml
@@ -23,21 +23,23 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
 
-    <artifactId>terminology-service-core</artifactId>
-    <name>FHIR Terminology Service Core</name>
+    <artifactId>common</artifactId>
+    <name>Health Patterns Common Component</name>
 
-    <dependencies>
-        <dependency>
-            <groupId>com.ibm.healthpatterns</groupId>
-            <artifactId>common</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>com.ibm.healthpatterns</groupId>
-            <artifactId>common</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>        
-    </dependencies>    
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>2.2</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test-jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/services/common/src/main/java/com/ibm/healthpatterns/core/FHIRService.java
+++ b/services/common/src/main/java/com/ibm/healthpatterns/core/FHIRService.java
@@ -1,0 +1,235 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.healthpatterns.core;
+
+import java.io.IOException;
+
+import java.io.StringWriter;
+import java.io.Writer;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpStatus;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.client.api.IClientInterceptor;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.client.interceptor.BasicAuthInterceptor;
+
+/**
+ * A {@link FHIRService} is a class that provides some functionality using a FHIR Server.
+ * <p>
+ * It provides an implementation of a {@link #healthCheck(StringWriter)} that allows consumers 
+ * to know whether the FHIR Server is available, and extenders can extend the method to complement
+ * additional health checks to other services that may be used.
+ *  
+ * @author Luis A. García
+ */
+public class FHIRService {
+
+	/**
+	 * The path to check the FHIR server health.
+	 */
+	private static final String FHIR_HEALTHCHECK_PATH = "/$healthcheck";
+	
+	/**
+	 * A FHIR resource's Bundle resource type
+	 */
+	private static final String BUNDLE_RESOURCE_TYPE = "Bundle";
+	
+	/**
+	 * A FHIR resource's 'resource' field 
+	 */
+	protected static final String RESOURCE_OBJECT = "resource";
+
+	/**
+	 * A FHIR resource's 'resourceType' field 
+	 */
+	protected static final String RESOURCE_TYPE_OBJECT = "resourceType";
+
+	/**
+	 * A FHIR resource's 'entry' field
+	 */
+	protected static final String ENTRY_OBJECT = "entry";
+
+	protected ObjectMapper jsonDeserializer;
+	
+	protected IGenericClient fhirClient;
+	private CloseableHttpClient rawFhirClient;
+
+	/**
+	 * Creates a FHIR Service backed by the given FHIR server.
+	 * 
+	 * @param fhirServerURL the full FHIR server base URL, e.g. http://fhir-us-south.lb.appdomain.cloud:8080/fhir-server/api/v4
+	 * @param fhirServerUsername the FHIR server username
+	 * @param fhirServerPassword the FHIR server password
+	 */
+	public FHIRService(String fhirServerURL, String fhirServerUsername, String fhirServerPassword) {
+		jsonDeserializer = new ObjectMapper();
+		initializeFhirClients(fhirServerURL, fhirServerUsername, fhirServerPassword);
+	}
+	
+	/**
+	 * Initializes the FHIR Clients. There is an official Hapi FHIR Client and a plain Apache HttpClient that
+	 * get initialized to connect to the FHIR Server.
+	 *  
+	 * @param fhirServerURL the FHIR server URL
+	 * @param fhirServerUsername the FHIR server username
+	 * @param fhirServerPassword the FHIR server password
+	 */
+	private void initializeFhirClients(String fhirServerURL, String fhirServerUsername, String fhirServerPassword) {
+		// Initialize the Hapi FHIR client to perform all general FHIR operations
+		FhirContext context = FhirContext.forR4();
+		// Large synthea Bundles need a longer timeout than the default
+		context.getRestfulClientFactory().setSocketTimeout(200 * 1000);
+		fhirClient = context.newRestfulGenericClient(fhirServerURL);
+		// https://hapifhir.io/hapi-fhir/docs/interceptors/built_in_client_interceptors.html#section2
+		IClientInterceptor authInterceptor = new BasicAuthInterceptor(fhirServerUsername, fhirServerPassword);
+		fhirClient.registerInterceptor(authInterceptor);
+		
+		// Initialize the raw FHIR client to perform IBM specific FHIR operations, e.g. $healthcheck
+		if (fhirServerUsername == null) {
+			rawFhirClient = HttpClients.createDefault();
+		} else {
+			CredentialsProvider credentialsPovider = new BasicCredentialsProvider();
+			URL url;
+			try {
+				url = new URL(fhirClient.getServerBase());
+			} catch (MalformedURLException e) {
+				System.err.println("Incorrect FHIR server URL provided: " + e.getMessage());
+				return;
+			}
+			credentialsPovider.setCredentials(new AuthScope(url.getHost(), url.getPort()), new UsernamePasswordCredentials(fhirServerUsername, fhirServerPassword));
+			rawFhirClient = HttpClients.custom()
+					.setDefaultCredentialsProvider(credentialsPovider)
+					.build();
+		}
+	}
+
+	/**
+	 * Checks the health of the underlying services using the services' corresponding health check APIs.
+	 * <p>
+	 * If the services are healthy the service returns true, otherwise the services return false.
+	 * In either case the given {@link Writer} will be used by the method to populate more information about
+	 * what exactly is went wrong.
+	 * <p>
+	 * It is possible for subclasses to call this method and pick up on their specific health check as needed
+	 * if other services other than a FHIR server is used. 
+	 *  
+	 * @param status an optional {@link StringWriter} where status will be logged 
+	 * @return true if the service is healthy, false otherwise
+	 */
+	public boolean healthCheck(StringWriter status) {
+		boolean errors = false;
+		if (status == null) {
+			status = new StringWriter();
+		}
+		if (!checkFHIRHealth(status)) {
+			errors = true;
+		}
+		return !errors;
+	}
+
+	/**
+	 * Check the health of the FHIR server.
+	 * 
+	 * @param status the status to write to
+	 * @return true if FHIR server is OK, false otherwise
+	 */
+	private boolean checkFHIRHealth(StringWriter status) {
+		boolean errors = false;
+		HttpGet getRequest = new HttpGet(fhirClient.getServerBase() + FHIR_HEALTHCHECK_PATH);
+		try (CloseableHttpResponse response = rawFhirClient.execute(getRequest)) {
+	    	EntityUtils.consume(response.getEntity());
+	        if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+	        	status.write("FHIR Server OK!\n");
+	        } else if (response.getStatusLine().getStatusCode() == HttpStatus.SC_UNAUTHORIZED) {
+	        	status.write("The FHIR Server credentials are incorrect, please verify:\n");
+	        	status.write("> " + getRequest.getRequestLine() + "\n");
+	        	HttpEntity entity = response.getEntity();
+	        	String responseString = EntityUtils.toString(entity, "UTF-8");
+	        	status.write("< " + response.getStatusLine().toString() + "\n");
+	        	status.write(responseString + "\n");
+	        	errors = true;
+	        } else {
+	        	status.write("There is an unknown problem in the FHIR Server:\n");
+	        	status.write("> " + getRequest.getRequestLine() + "\n");
+	        	HttpEntity entity = response.getEntity();
+	        	String responseString = EntityUtils.toString(entity, "UTF-8");
+	        	status.write("< " + response.getStatusLine().toString() + "\n");
+	        	status.write(responseString + "\n");
+	        	errors = true;
+	        }
+	    } catch (ClientProtocolException e) {
+	    	status.write("There is a problem in the FHIR Server.\n");
+	    	status.write("HTTP protocol error executing request: " + getRequest.getRequestLine() + " - " + e.getMessage() + "\n");
+	    	errors = true;
+		} catch (IOException e) {
+			status.write("There is a problem in the FHIR Server.\n");
+			status.write("HTTP I/O connection error executing request: " + getRequest.getRequestLine() + " - " + e.getMessage() + "\n");
+			errors = true;
+		}
+		return !errors;
+	}
+
+	/**
+	 * Determines whether the given {@link JsonNode} represents a FHIR Bundle
+	 *  
+	 * @param jsonNode the json to check
+	 * @return true if the 'resourceType' of the given FHIR resource is Bundle, false otherwise
+	 */
+	protected boolean isBundle(JsonNode jsonNode) {
+		return BUNDLE_RESOURCE_TYPE.equals(getResourceType(jsonNode));
+	}
+
+	/**
+	 * Extract the resource type from the given JSON object.
+	 * 
+	 * @param json the json resource
+	 * @return the resource type, or null if no resource type is included in this JSON
+	 */
+	protected String getResourceType(JsonNode json) {
+		JsonNode resourceType = json.findValue(RESOURCE_TYPE_OBJECT);
+		if (resourceType == null) {
+			return null;
+		}
+		return resourceType.asText();
+	}
+
+	/**
+	 * @return the fhirClient used by this {@link FHIRService}
+	 */
+	public IGenericClient getFhirClient() {
+		return fhirClient;
+	}
+}

--- a/services/common/src/main/java/com/ibm/healthpatterns/core/FHIRServiceException.java
+++ b/services/common/src/main/java/com/ibm/healthpatterns/core/FHIRServiceException.java
@@ -16,24 +16,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.ibm.healthpatterns.deid;
-
-import com.ibm.healthpatterns.core.FHIRServiceException;
+package com.ibm.healthpatterns.core;
 
 /**
+ * A problem occurred with this service.
+ * 
  * @author Luis A. García
  */
-public class DeIdentifierException extends FHIRServiceException {
+public class FHIRServiceException extends Exception {
 
 	/**
 	 * 
 	 */
-	private static final long serialVersionUID = -2447683821098809222L;
+	private static final long serialVersionUID = -6306314160788650883L;
 
 	/**
 	 * @param msg
 	 */
-	public DeIdentifierException(String msg) {
+	public FHIRServiceException(String msg) {
 		super(msg);
 	}
 
@@ -41,7 +41,7 @@ public class DeIdentifierException extends FHIRServiceException {
 	 * @param msg 
 	 * @param cause 
 	 */
-	public DeIdentifierException(String msg, Exception cause) {
+	public FHIRServiceException(String msg, Exception cause) {
 		super(msg, cause);
 	}
 }

--- a/services/common/src/test/java/com/ibm/healthpatterns/core/FHIRServiceTest.java
+++ b/services/common/src/test/java/com/ibm/healthpatterns/core/FHIRServiceTest.java
@@ -1,0 +1,85 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.healthpatterns.core;
+
+import java.util.ArrayList;
+
+import java.util.List;
+
+import org.junit.After;
+
+/**
+ * Base test for a {@link FHIRService}
+ * 
+ * @author Luis A. García
+ */
+public abstract class FHIRServiceTest {
+
+	protected String fhirURL;
+	protected String fhirUsername;
+	protected String fhirPassword;
+	
+	protected List<String> createdResources;	
+
+	/**
+	 * Create a {@link FHIRServiceTest} pointing to the existing IBM Cloud tet FHIR server.
+	 */
+	public FHIRServiceTest() {
+		// This URLs is for an IBM FHIR server setup specifically to run these tests
+		fhirURL = "http://4603f72b-us-south.lb.appdomain.cloud/fhir-server/api/v4";
+		fhirUsername = "fhiruser";
+		fhirPassword = "integrati0n";
+		createdResources = new ArrayList<String>();
+	}
+
+	/**
+	 * Clean up the FHIR resources created by this test.
+	 * <p>
+	 * The URIs saved by the test cases can be of the form:
+	 * - http://server/fhir-server/api/v4/{ResourceType}/{id}/_history/{version}
+	 * - http://server/fhir-server/api/v4/{ResourceType}/{id}
+	 */
+	@After
+	public void cleanUpFHIR() {
+		for (String uri : createdResources) {
+			String[] uriElements = uri.split("/");
+			String id;
+			String type;
+			if (uri.contains("_history")) {
+				id = uriElements[uriElements.length - 3];
+				type = uriElements[uriElements.length - 4];
+			} else {
+				id = uriElements[uriElements.length - 1];
+				type = uriElements[uriElements.length - 2];
+			}
+			System.out.println("Deleting " + type + " resource " + id);
+			getFHIRService().getFhirClient()
+					.delete()
+					.resourceById(type, id)
+					.execute();
+		}
+		System.out.println("------------------");
+		System.out.println();
+	}
+
+	/**
+	 * @return the FHIR client used to test this FHIR service
+	 */
+	protected abstract FHIRService getFHIRService();
+}

--- a/services/deid-core/pom.xml
+++ b/services/deid-core/pom.xml
@@ -26,11 +26,18 @@
     <artifactId>deid-core</artifactId>
     <name>De-Identification Core</name>
 
-	<dependencies>
-	   <dependency>
-		  <groupId>com.fasterxml.jackson.core</groupId>
-		  <artifactId>jackson-core</artifactId>
-		  <version>2.11.2</version>
-	   </dependency>
-	</dependencies>
+    <dependencies>
+        <dependency>
+	        <groupId>com.ibm.healthpatterns</groupId>
+	        <artifactId>common</artifactId>
+	        <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+		<dependency>
+            <groupId>com.ibm.healthpatterns</groupId>
+            <artifactId>common</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+    </dependencies>
 </project>

--- a/services/deid-core/src/test/java/com/ibm/healthpatterns/deid/DeIdentifierTest.java
+++ b/services/deid-core/src/test/java/com/ibm/healthpatterns/deid/DeIdentifierTest.java
@@ -32,14 +32,14 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.io.IOUtils;
-import org.junit.After;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.ibm.healthpatterns.core.FHIRService;
+import com.ibm.healthpatterns.core.FHIRServiceTest;
 
 /**
  * This test runs the {@link DeIdentifier} against a real de-id service and FHIR server dedicated 
@@ -50,48 +50,19 @@ import com.fasterxml.jackson.databind.JsonNode;
  *  
  * @author Luis A. García
  */
-public class DeIdentifierTest {
+public class DeIdentifierTest extends FHIRServiceTest {
 
 	private DeIdentifier deid;
-	private List<String> createdResources;
-	
 	private String deidURL;
-	private String fhirURL;
-	private String fhirUsername;
-	private String fhirPassword;
-
+	
 	/**
 	 * 
 	 */
 	public DeIdentifierTest() {
-		// These URLs are for two IBM Cloud services that we setup specifically to run these tests
 		deidURL = "http://3a5d0fa4-us-south.lb.appdomain.cloud:8080/api/v1";
-		fhirURL = "http://4603f72b-us-south.lb.appdomain.cloud/fhir-server/api/v4";
-		fhirUsername = "fhiruser";
-		fhirPassword = "integrati0n";
 		deid = new DeIdentifier(deidURL, fhirURL, fhirUsername, fhirPassword);
-		createdResources = new ArrayList<String>();
 	}
 
-	/**
-	 * Clean up the FHIR resources created by this test 
-	 */
-	@After
-	public void cleanUpFHIR() {
-		for (String uri : createdResources) {
-			String[] uriElements = uri.split("/");
-			String id = uriElements[uriElements.length - 3];
-			String type = uriElements[uriElements.length - 4];
-			System.out.println("Deleting " + type + " resource " + id);
-			deid.getFhirClient()
-					.delete()
-					.resourceById(type, id)
-					.execute();
-		}
-		System.out.println("------------------");
-		System.out.println();
-	}
-	
 	/**
 	 * Test method for {@link com.ibm.healthpatterns.deid.DeIdentifier#healthCheck(java.io.StringWriter)}.
 	 */
@@ -220,5 +191,12 @@ public class DeIdentifierTest {
 		InputStream inputStream = IOUtils.toInputStream("some bad JSON", Charset.forName("UTF-8"));
 		deid.deIdentify(inputStream);
 	}
-	
+
+	/* (non-Javadoc)
+	 * @see com.ibm.healthpatterns.core.FHIRServiceTest#getFHIRService()
+	 */
+	@Override
+	protected FHIRService getFHIRService() {
+		return deid;
+	}
 }

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -35,8 +35,9 @@
     </properties>
 
     <modules>
+        <module>common</module>        
         <module>deid-core</module>
-        <module>terminology-service-core</module>        
+        <module>terminology-service-core</module>
     </modules>
     
     <dependencies>
@@ -72,6 +73,14 @@
 			<artifactId>hapi-fhir-structures-r4</artifactId>
 			<version>${hapi.fhir.version}</version>
 		</dependency>
+
+        <!-- JSON Parsing -->
+       <dependency>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+          <version>2.11.2</version>
+       </dependency>
+
 
         <!-- Logging dependencies -->
 		<dependency>

--- a/services/terminology-service-core/src/test/java/com/ibm/healthpatterns/terminology/TerminologyServiceTest.java
+++ b/services/terminology-service-core/src/test/java/com/ibm/healthpatterns/terminology/TerminologyServiceTest.java
@@ -31,14 +31,13 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.commons.io.IOUtils;
-import org.junit.After;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.ibm.healthpatterns.core.FHIRService;
+import com.ibm.healthpatterns.core.FHIRServiceTest;
 
 /**
  * This test runs the {@link TerminologyService} against a real FHIR server dedicated 
@@ -49,46 +48,17 @@ import com.fasterxml.jackson.databind.JsonNode;
  *  
  * @author Luis A. García
  */
-public class TerminologyServiceTest {
+public class TerminologyServiceTest extends FHIRServiceTest {
 
 	private TerminologyService terminology;
-	private List<String> createdResources;
 	
-	private String fhirURL;
-	private String fhirUsername;
-	private String fhirPassword;
-
 	/**
 	 * 
 	 */
 	public TerminologyServiceTest() {
-		// This URL is for two IBM Cloud services that we setup specifically to run these tests
-		fhirURL = "http://4603f72b-us-south.lb.appdomain.cloud/fhir-server/api/v4";
-		fhirUsername = "fhiruser";
-		fhirPassword = "integrati0n";
 		terminology = new TerminologyService(fhirURL, fhirUsername, fhirPassword);
-		createdResources = new ArrayList<String>();
 	}
 
-	/**
-	 * Clean up the FHIR resources created by this test 
-	 */
-	@After
-	public void cleanUpFHIR() {
-		for (String uri : createdResources) {
-			String[] uriElements = uri.split("/");
-			String id = uriElements[uriElements.length - 1];
-			String type = uriElements[uriElements.length - 2];
-			System.out.println("Deleting " + type + " resource " + id);
-			terminology.getFhirClient()
-					.delete()
-					.resourceById(type, id)
-					.execute();
-		}
-		System.out.println("------------------");
-		System.out.println();
-	}
-	
 	/**
 	 * Test method for {@link com.ibm.healthpatterns.terminology.TerminologyService#healthCheck(java.io.StringWriter)}.
 	 */
@@ -131,7 +101,7 @@ public class TerminologyServiceTest {
 	 * @throws TerminologyServiceException 
 	 */
 	@Test
-	public void testTranslateResource() throws IOException, TerminologyServiceException{
+	public void testTranslateResource() throws IOException, TerminologyServiceException {
 		// This first pass tests (in addition to the actual translation) 
 		// the path were the FHIR Terminology Service resources are installed from scratch on the FHIR server
 		Path jsonFile = Paths.get("src/test/resources/Antonia30_Acosta403_Patient.json");
@@ -241,6 +211,14 @@ public class TerminologyServiceTest {
 	public void testTranslateBadJSON() throws IOException, TerminologyServiceException {
 		InputStream inputStream = IOUtils.toInputStream("some bad JSON", Charset.forName("UTF-8"));
 		terminology.translate(inputStream);
+	}
+
+	/* (non-Javadoc)
+	 * @see com.ibm.healthpatterns.core.FHIRServiceTest#getFHIRService()
+	 */
+	@Override
+	protected FHIRService getFHIRService() {
+		return terminology;
 	}
 	
 }


### PR DESCRIPTION
The de-id and terminology service use cases both require communication
to the FHIR Server and they had several similarities in terms of both
their implementation and testing.

This commit implements a refactoring extracting the common code into a
new couple of classes FHIRService and FHIRServieTest, that live in a new
project called common.

Refactoring the tests of the custom processors to extract commonalities
is also included in this commit.

The corresponding necessary build changes to build and get the right
visibility on the child projects are included too.

This is what the reactor currently looks like after this commit:

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Alvearie Health Patterns - Core Services 0.0.1-SNAPSHOT:
[INFO] 
[INFO] Alvearie Health Patterns - Core Services ........... SUCCESS [  0.378 s]
[INFO] Health Patterns Common Component ................... SUCCESS [  2.914 s]
[INFO] De-Identification Core ............................. SUCCESS [  7.868 s]
[INFO] FHIR Terminology Service Core ...................... SUCCESS [  8.365 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  19.660 s
```