### PR TITLE
Update README.md

### DIFF
--- a/clinical-ingestion/README.md
+++ b/clinical-ingestion/README.md
@@ -66,6 +66,8 @@ There are two ways to easily run a FHIR bundle through Clinical Ingestion Flow o
 	* "path/to/json" can refer to any FHIR bundle you wish to process. For example, "patientData/patient-with-us-core-birthsex.json"
 	* NIFI_SERVER and FHIR_LISTEN_PORT should be known values from the setup above.
 	* The result of this command should be an HTTP 200 response indicating that it was successfully submitted.
+	* It is also possible to use a special HTTP header *filename* with a user generated ID. When providing this, that header will be persisted throughout the Ingestion pipeline as a flow file attribute, in order to match any user request to its corresponding flow file. Sample usage:
+	    * `curl -X POST --header "filename: request-0001" -d @<<path/to/json>> "<<NIFI_SERVER>>:<<FHIR_LISTEN_PORT>>/fhirResource" --verbose`
 
 2. Submit the FHIR bundle to the kafka topic configured above ("kafka.topic.in" parameter in "Clinical Ingestion Kafka Parameter Context")
 	* Using the configured kafka broker ("kafka.brokers" parameter in "Clinical Ingestion Kafka Parameter Context"), post the FHIR bundle of your choice and the Clinical Ingestion Flow will automatically react and begin processing.

--- a/clinical-ingestion/README.md
+++ b/clinical-ingestion/README.md
@@ -66,8 +66,8 @@ There are two ways to easily run a FHIR bundle through Clinical Ingestion Flow o
 	* "path/to/json" can refer to any FHIR bundle you wish to process. For example, "patientData/patient-with-us-core-birthsex.json"
 	* NIFI_SERVER and FHIR_LISTEN_PORT should be known values from the setup above.
 	* The result of this command should be an HTTP 200 response indicating that it was successfully submitted.
-	* It is also possible to use a special HTTP header *filename* with a user generated ID. When providing this, that header will be persisted throughout the Ingestion pipeline as a flow file attribute, in order to match any user request to its corresponding flow file. Sample usage:
-	    * `curl -X POST --header "filename: request-0001" -d @<<path/to/json>> "<<NIFI_SERVER>>:<<FHIR_LISTEN_PORT>>/fhirResource" --verbose`
+	* It is also possible to use a special HTTP header *RequestId* with a user generated ID. When providing this, that header will be persisted throughout the Ingestion pipeline as a flow file attribute, in order to match any user request to its corresponding flow file. Sample usage:
+	    * `curl -X POST --header "RequestId: request-0001" -d @<<path/to/json>> "<<NIFI_SERVER>>:<<FHIR_LISTEN_PORT>>/fhirResource" --verbose`
 
 2. Submit the FHIR bundle to the kafka topic configured above ("kafka.topic.in" parameter in "Clinical Ingestion Kafka Parameter Context")
 	* Using the configured kafka broker ("kafka.brokers" parameter in "Clinical Ingestion Kafka Parameter Context"), post the FHIR bundle of your choice and the Clinical Ingestion Flow will automatically react and begin processing.


### PR DESCRIPTION
Add details on how to create a reference between a HTTP FHIR resource request and its resulting flow files.

The ListenHTTP processor originally used to create a server within the NiFi canvas accept HTTP requests with FHIR resources does not offer the ability to send back HTTP response headers or body to the requestor. However, it does allow the user to send in an HTTP request header called *RequestId* which will be persisted throughout the whole NiFi flow, and this way a user can match their requests against resulting flow files.

The corresponding NiFi Flow update will be made next Monday after the demos.

Updated documentation.