### PR TITLE
Atc rename nifi api

### DIFF
--- a/clinical-ingestion/helm-charts/alvearie-ingestion/Chart.yaml
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.2
+version: 0.5.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/clinical-ingestion/helm-charts/alvearie-ingestion/templates/NOTES.txt
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/templates/NOTES.txt
@@ -25,7 +25,7 @@ The following services have been deployed:
 {{- end }}
 {{- if .Values.nifi.enabled }}
 - NiFi Server{{- if .Values.ingress.enabled }} ---------------- http://{{ .Release.Namespace }}.{{ .Release.Name }}-nifi.{{ .Values.ingress.subdomain}}/nifi{{- end }}
-- NiFi REST API{{- if .Values.ingress.enabled }} -------------- http://{{ .Release.Namespace }}.{{ .Release.Name }}-nifi-rest.{{ .Values.ingress.subdomain}}{{- end }}
+- NiFi HTTP Post API{{- if .Values.ingress.enabled }} -------------- http://{{ .Release.Namespace }}.{{ .Release.Name }}-nifi-http-post.{{ .Values.ingress.subdomain}}{{- end }}
 {{- end }}
 {{- if index .Values "nifi-registry" "enabled" }}
 - NiFi Registry{{- if .Values.ingress.enabled }} -------------- http://{{ .Release.Namespace }}.{{ .Release.Name }}-nifi-registry.{{ .Values.ingress.subdomain}}/nifi-registry{{- end }}

--- a/clinical-ingestion/helm-charts/alvearie-ingestion/templates/ingress-nifi-http-post.yaml
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/templates/ingress-nifi-http-post.yaml
@@ -14,7 +14,7 @@ metadata:
     kubernetes.io/ingress.class: public-iks-k8s-nginx # Required for IBM Cloud Ingresses
 spec:
   rules:
-    - host: {{ .Release.Namespace }}.{{ .Release.Name }}-nifi-rest.{{ .Values.ingress.subdomain}}
+    - host: {{ .Release.Namespace }}.{{ .Release.Name }}-nifi-http-post.{{ .Values.ingress.subdomain}}
       http:
         paths:
           - path: /

--- a/clinical-ingestion/helm-charts/alvearie-ingestion/templates/ingress-nifi-http-post.yaml
+++ b/clinical-ingestion/helm-charts/alvearie-ingestion/templates/ingress-nifi-http-post.yaml
@@ -4,7 +4,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ .Release.Name }}-nifi-rest-ingress
+  name: {{ .Release.Name }}-nifi-http-post-ingress
   namespace: {{ .Release.Namespace }}
   {{- with .Values.nifi.labels }}
   labels:


### PR DESCRIPTION
I missed renaming a few places that still referred to the nifi input port as 'REST' - so fixing it to call it the Nifi HTTP Post API.  Not perfect, but better.