### PR TITLE
Resolved: Update HL7toFhirProcessor to use Callbacks

### DIFF
--- a/nifi-processors/nifi-health-patterns-bundle/nifi-health-patterns-processors/src/main/java/com/ibm/healthpatterns/processors/hl7tofhir/HL7ToFhirProcessor.java
+++ b/nifi-processors/nifi-health-patterns-bundle/nifi-health-patterns-processors/src/main/java/com/ibm/healthpatterns/processors/hl7tofhir/HL7ToFhirProcessor.java
@@ -219,5 +219,5 @@ public class HL7ToFhirProcessor extends AbstractProcessor {
           session.transfer(inputFlowFile, FAIL_RELATIONSHIP);
           return; // if the input data can't be converted to FHIR then stop
         }
-      }
+    }
 }

--- a/nifi-processors/nifi-health-patterns-bundle/nifi-health-patterns-processors/src/main/java/com/ibm/healthpatterns/processors/hl7tofhir/HL7ToFhirProcessor.java
+++ b/nifi-processors/nifi-health-patterns-bundle/nifi-health-patterns-processors/src/main/java/com/ibm/healthpatterns/processors/hl7tofhir/HL7ToFhirProcessor.java
@@ -128,96 +128,96 @@ public class HL7ToFhirProcessor extends AbstractProcessor {
      */
 
     @Override
-    public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
-        FlowFile inputFlowFile = session.get();
-        if (inputFlowFile == null) {
-            return; // if there is no flowfile present then stop
-        }
+    public void onTrigger(final ProcessContext context, final ProcessSession session)
+        throws ProcessException {
+      FlowFile inputFlowFile = session.get();
+      if (inputFlowFile == null) {
+        return; // if there is no flowfile present then stop
+      }
 
-        getLogger().info("Reading text data from FlowFile");
-        
-        AtomicReference<String> uploadDataRate = new AtomicReference<String>();
-        AtomicLong uploadMillis = new AtomicLong();        
-        final StopWatch stopWatch = new StopWatch(true);
-        AtomicReference<String> callBackMessage = new AtomicReference<String>();
-        
-        session.read(inputFlowFile, new InputStreamCallback() {
+      getLogger().info("Reading text data from FlowFile");
+
+      AtomicReference<String> uploadDataRate = new AtomicReference<String>();
+      AtomicLong uploadMillis = new AtomicLong();
+      final StopWatch stopWatch = new StopWatch(true);
+      AtomicReference<String> callBackMessage = new AtomicReference<String>();
+
+      session.read(inputFlowFile, new InputStreamCallback() {
+        /*
+         * (non-Javadoc)
+         * 
+         * @see org.apache.nifi.processor.io.InputStreamCallback#process(java.io.InputStream)
+         */
+        @Override
+        public void process(InputStream in) throws IOException {
+          try (BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
+            StringBuilder sb = new StringBuilder();
+            String line = null;
+            while ((line = reader.readLine()) != null) {
+              sb.append(line + "\n");
+            }
+            callBackMessage.set(sb.toString());
+            stopWatch.stop();
+            uploadMillis.set(stopWatch.getDuration(TimeUnit.MILLISECONDS));
+            uploadDataRate.set(stopWatch.calculateDataRate(inputFlowFile.getSize()));
+          } catch (IOException e) {
+            getLogger().error("Error reading flowfile", e);
+            session.transfer(inputFlowFile, FAIL_RELATIONSHIP);
+            return;
+          }
+        }
+      });
+
+      getLogger().info("Successfully read input data in {} at a rate of {}",
+          new Object[] {FormatUtils.formatMinutesSeconds(uploadMillis.get(), TimeUnit.MILLISECONDS),
+              uploadDataRate.get()});
+
+      String inputMessage = callBackMessage.get();
+      if (inputMessage == null || inputMessage.length() == 0) {
+        session.transfer(inputFlowFile, FAIL_RELATIONSHIP);
+        return; // if the incoming data is empty then stop
+      }
+
+      try {
+        new HL7HapiParser().getParser().parse(inputMessage.toString());
+      } catch (HL7Exception e) {
+        session.transfer(inputFlowFile, HL7_NOT_DETECTED_RELATIONSHIP);
+        return; // if the input data can't be parsed as HL7 then stop
+      }
+
+      try {
+        String hl7Message = inputMessage.toString();
+        HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+        String fhirMessage = ftv.convert(hl7Message); // generated a FHIR output
+
+        FlowFile outputFlowFile = session.clone(inputFlowFile);
+
+        outputFlowFile = session.write(outputFlowFile, new OutputStreamCallback() {
           /*
            * (non-Javadoc)
            * 
-           * @see org.apache.nifi.processor.io.InputStreamCallback#process(java.io.InputStream)
+           * @see org.apache.nifi.processor.io.OutputStreamCallback#process(java.io.OutputStream)
            */
           @Override
-          public void process(InputStream in) throws IOException {
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
-              StringBuilder sb = new StringBuilder();
-              String line = null;
-              while ((line = reader.readLine()) != null) {
-                sb.append(line + "\n");
-              }
-              callBackMessage.set(sb.toString());
-              stopWatch.stop();
-              uploadMillis.set(stopWatch.getDuration(TimeUnit.MILLISECONDS));
-              uploadDataRate.set(stopWatch.calculateDataRate(inputFlowFile.getSize()));
+          public void process(OutputStream out) throws IOException {
+            try (OutputStream outputStream = new BufferedOutputStream(out)) {
+              outputStream.write(fhirMessage.getBytes(StandardCharsets.UTF_8));
             } catch (IOException e) {
-              getLogger().error("Error reading flowfile", e);
+              getLogger().error("Error writing FHIR message to output flow", e);
               session.transfer(inputFlowFile, FAIL_RELATIONSHIP);
-              return;
-           }
+              return; // if the input data can't be parsed as HL7 then stop
+            }
           }
         });
 
-        getLogger().info("Successfully read input data in {} at a rate of {}",
-            new Object[] {
-                FormatUtils.formatMinutesSeconds(uploadMillis.get(), TimeUnit.MILLISECONDS),
-                uploadDataRate.get()});
-
-        String inputMessage = callBackMessage.get();
-        if (inputMessage == null || inputMessage.length() == 0) {
-            session.transfer(inputFlowFile, FAIL_RELATIONSHIP);
-            return; // if the incoming data is empty then stop
-        }
-
-        try {
-            new HL7HapiParser().getParser().parse(inputMessage.toString());
-        } catch (HL7Exception e) {
-            session.transfer(inputFlowFile, HL7_NOT_DETECTED_RELATIONSHIP);
-            return; // if the input data can't be parsed as HL7 then stop
-        }
-
-        try {
-          String hl7Message = inputMessage.toString();
-          HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-          String fhirMessage = ftv.convert(hl7Message); // generated a FHIR output
-
-          FlowFile outputFlowFile = session.clone(inputFlowFile);
-
-          outputFlowFile = session.write(outputFlowFile, new OutputStreamCallback() {
-            /*
-             * (non-Javadoc)
-             * 
-             * @see org.apache.nifi.processor.io.OutputStreamCallback#process(java.io.OutputStream)
-             */
-            @Override
-            public void process(OutputStream out) throws IOException {
-              try (OutputStream outputStream = new BufferedOutputStream(out)) {
-                outputStream.write(fhirMessage.getBytes(StandardCharsets.UTF_8));
-              } catch (IOException e) {
-                getLogger().error("Error writing FHIR message to output flow", e);
-                session.transfer(inputFlowFile, FAIL_RELATIONSHIP);
-                return; // if the input data can't be parsed as HL7 then stop
-              }
-            }
-          });
-
-          session.putAttribute(outputFlowFile, CoreAttributes.MIME_TYPE.key(), APPLICATION_JSON);
-          session.transfer(outputFlowFile, SUCCESS_RELATIONSHIP);
-          session.remove(inputFlowFile); // remove the original flow file and stop
-          getLogger().info("Pass FHIR flowfile to success queue");
-        } catch (UnsupportedOperationException | IllegalArgumentException e) {
-          getLogger().error("Error converting HL7 data to FHIR", e);
-          session.transfer(inputFlowFile, FAIL_RELATIONSHIP);
-          return; // if the input data can't be converted to FHIR then stop
-        }
+        session.putAttribute(outputFlowFile, CoreAttributes.MIME_TYPE.key(), APPLICATION_JSON);
+        session.transfer(outputFlowFile, SUCCESS_RELATIONSHIP);
+        session.remove(inputFlowFile); // remove the original flow file and stop
+        getLogger().info("Pass FHIR flowfile to success queue");
+      } catch (UnsupportedOperationException | IllegalArgumentException e) {
+        getLogger().error("Error converting HL7 data to FHIR", e);
+        session.transfer(inputFlowFile, FAIL_RELATIONSHIP);
+        return; // if the input data can't be converted to FHIR then stop
+      }
     }
 }

--- a/nifi-processors/nifi-health-patterns-bundle/nifi-health-patterns-processors/src/main/java/com/ibm/healthpatterns/processors/hl7tofhir/HL7ToFhirProcessor.java
+++ b/nifi-processors/nifi-health-patterns-bundle/nifi-health-patterns-processors/src/main/java/com/ibm/healthpatterns/processors/hl7tofhir/HL7ToFhirProcessor.java
@@ -16,16 +16,21 @@
  */
 package com.ibm.healthpatterns.processors.hl7tofhir;
 
+import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.components.PropertyDescriptor;
@@ -37,6 +42,10 @@ import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.ProcessorInitializationContext;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.io.InputStreamCallback;
+import org.apache.nifi.processor.io.OutputStreamCallback;
+import org.apache.nifi.util.FormatUtils;
+import org.apache.nifi.util.StopWatch;
 import ca.uhn.hl7v2.HL7Exception;
 import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
 import io.github.linuxforhealth.hl7.parsing.HL7HapiParser;
@@ -126,19 +135,44 @@ public class HL7ToFhirProcessor extends AbstractProcessor {
         }
 
         getLogger().info("Reading text data from FlowFile");
-        InputStream is = session.read(inputFlowFile);
-        StringBuilder inputMessage = new StringBuilder();
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
-            String line = null;
-            while ((line = reader.readLine()) != null) {
-                inputMessage.append(line + "\n");
-            }
-        } catch (IOException e) {
-            getLogger().error("Error reading flowfile", e);
-            session.transfer(inputFlowFile, FAIL_RELATIONSHIP);
-            return; // if an error occurred reading the input flowfile then stop
-        }
+        
+        AtomicReference<String> uploadDataRate = new AtomicReference<String>();
+        AtomicLong uploadMillis = new AtomicLong();        
+        final StopWatch stopWatch = new StopWatch(true);
+        AtomicReference<String> callBackMessage = new AtomicReference<String>();
+        
+        session.read(inputFlowFile, new InputStreamCallback() {
+          /*
+           * (non-Javadoc)
+           * 
+           * @see org.apache.nifi.processor.io.InputStreamCallback#process(java.io.InputStream)
+           */
+          @Override
+          public void process(InputStream in) throws IOException {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
+              StringBuilder sb = new StringBuilder();
+              String line = null;
+              while ((line = reader.readLine()) != null) {
+                sb.append(line + "\n");
+              }
+              callBackMessage.set(sb.toString());
+              stopWatch.stop();
+              uploadMillis.set(stopWatch.getDuration(TimeUnit.MILLISECONDS));
+              uploadDataRate.set(stopWatch.calculateDataRate(inputFlowFile.getSize()));
+            } catch (IOException e) {
+              getLogger().error("Error reading flowfile", e);
+              session.transfer(inputFlowFile, FAIL_RELATIONSHIP);
+              return;
+           }
+          }
+        });
 
+        getLogger().info("Successfully read input data in {} at a rate of {}",
+            new Object[] {
+                FormatUtils.formatMinutesSeconds(uploadMillis.get(), TimeUnit.MILLISECONDS),
+                uploadDataRate.get()});
+
+        String inputMessage = callBackMessage.get();
         if (inputMessage == null || inputMessage.length() == 0) {
             session.transfer(inputFlowFile, FAIL_RELATIONSHIP);
             return; // if the incoming data is empty then stop
@@ -151,28 +185,39 @@ public class HL7ToFhirProcessor extends AbstractProcessor {
             return; // if the input data can't be parsed as HL7 then stop
         }
 
-
         try {
-            String hl7Message = inputMessage.toString();
-            HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
-            String fhirMessage = ftv.convert(hl7Message); // generated a FHIR output
+          String hl7Message = inputMessage.toString();
+          HL7ToFHIRConverter ftv = new HL7ToFHIRConverter();
+          String fhirMessage = ftv.convert(hl7Message); // generated a FHIR output
 
-            FlowFile outputFlowFile = session.clone(inputFlowFile);
-            try (OutputStream newFlowOutput = session.write(outputFlowFile)) {
-                newFlowOutput.write(fhirMessage.getBytes());
-            } catch (IOException e) {
+          FlowFile outputFlowFile = session.clone(inputFlowFile);
+
+          outputFlowFile = session.write(outputFlowFile, new OutputStreamCallback() {
+            /*
+             * (non-Javadoc)
+             * 
+             * @see org.apache.nifi.processor.io.OutputStreamCallback#process(java.io.OutputStream)
+             */
+            @Override
+            public void process(OutputStream out) throws IOException {
+              try (OutputStream outputStream = new BufferedOutputStream(out)) {
+                outputStream.write(fhirMessage.getBytes(StandardCharsets.UTF_8));
+              } catch (IOException e) {
                 getLogger().error("Error writing FHIR message to output flow", e);
                 session.transfer(inputFlowFile, FAIL_RELATIONSHIP);
                 return; // if the input data can't be parsed as HL7 then stop
+              }
             }
-            session.putAttribute(outputFlowFile, CoreAttributes.MIME_TYPE.key(), APPLICATION_JSON);
-            session.transfer(outputFlowFile, SUCCESS_RELATIONSHIP);
-            session.remove(inputFlowFile); // remove the original flow file and stop
-            getLogger().info("Pass FHIR flowfile to success queue");
+          });
+
+          session.putAttribute(outputFlowFile, CoreAttributes.MIME_TYPE.key(), APPLICATION_JSON);
+          session.transfer(outputFlowFile, SUCCESS_RELATIONSHIP);
+          session.remove(inputFlowFile); // remove the original flow file and stop
+          getLogger().info("Pass FHIR flowfile to success queue");
         } catch (UnsupportedOperationException | IllegalArgumentException e) {
-            getLogger().error("Error converting HL7 data to FHIR", e);
-            session.transfer(inputFlowFile, FAIL_RELATIONSHIP);
-            return; // if the input data can't be converted to FHIR then stop
+          getLogger().error("Error converting HL7 data to FHIR", e);
+          session.transfer(inputFlowFile, FAIL_RELATIONSHIP);
+          return; // if the input data can't be converted to FHIR then stop
         }
-    }
+      }
 }

--- a/nifi-processors/nifi-health-patterns-bundle/nifi-health-patterns-processors/src/test/java/com/ibm/healthpatterns/processors/hl7tofhir/Hl7ToFhirProcessorTest.java
+++ b/nifi-processors/nifi-health-patterns-bundle/nifi-health-patterns-processors/src/test/java/com/ibm/healthpatterns/processors/hl7tofhir/Hl7ToFhirProcessorTest.java
@@ -7,8 +7,9 @@
 package com.ibm.healthpatterns.processors.hl7tofhir;
 
 import static org.junit.Assert.assertTrue;
-
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
@@ -30,12 +31,12 @@ public class Hl7ToFhirProcessorTest {
     }
 
     @Test
-    public void testProcessor() {
+    public void testHL7Data() {
         String content = "MSH|^~\\&|SE050|050|PACS|050|20120912011230||ADT^A01|102|T|2.6|||AL|NE\n" + "EVN||201209122222\n"
                 + "PID|0010||PID1234^5^M11^A^MR^HOSP~1234568965^^^USA^SS||DOE^JOHN^A^||19800202|F||W|111 TEST_STREET_NAME^^TEST_CITY^NY^111-1111^USA||(905)111-1111|||S|ZZ|12^^^124|34-13-312||||TEST_BIRTH_PLACE\n"
                 + "PV1|1|ff|yyy|EL|ABC||200^ATTEND_DOC_FAMILY_TEST^ATTEND_DOC_GIVEN_TEST|201^REFER_DOC_FAMILY_TEST^REFER_DOC_GIVEN_TEST|202^CONSULTING_DOC_FAMILY_TEST^CONSULTING_DOC_GIVEN_TEST|MED|||||B6|E|272^ADMITTING_DOC_FAMILY_TEST^ADMITTING_DOC_GIVEN_TEST||48390|||||||||||||||||||||||||201409122200|\n"
-                + "OBX|1|TX|1234||ECHOCARDIOGRAPHIC REPORT||||||F|||||2740^TRDSE^Janetary~2913^MRTTE^Darren^F~3065^MGHOBT^Paul^J~4723^LOTHDEW^Robert^L|\r\n"
-                + "AL1|1|DRUG|00000741^OXYCODONE||HYPOTENSION\n" + "AL1|2|DRUG|00001433^TRAMADOL||SEIZURES~VOMITING\r\n" + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625";
+                + "OBX|1|TX|1234||ECHOCARDIOGRAPHIC REPORT||||||F|||||2740^TRDSE^Janetary~2913^MRTTE^Darren^F~3065^MGHOBT^Paul^J~4723^LOTHDEW^Robert^L|"
+                + "AL1|1|DRUG|00000741^OXYCODONE||HYPOTENSION\n" + "AL1|2|DRUG|00001433^TRAMADOL||SEIZURES~VOMITING" + "PRB|AD|200603150625|aortic stenosis|53692||2||200603150625";
         // Add the content to the runner
         testRunner.enqueue(content);
 
@@ -45,13 +46,82 @@ public class Hl7ToFhirProcessorTest {
         // All results were processed with out failure
         testRunner.assertQueueEmpty();
 
-        List<MockFlowFile> flowFiles = testRunner.getFlowFilesForRelationship("success");
-        assertTrue("No Flow Files returned on success relationship", flowFiles != null && flowFiles.size() == 1);
+        // Validate Success Relationship
+        List<MockFlowFile> successFlowFiles = testRunner.getFlowFilesForRelationship(HL7ToFhirProcessor.SUCCESS_RELATIONSHIP);
+        assertTrue("No Flow Files returned on success relationship", successFlowFiles != null && successFlowFiles.size() == 1);
 
-        MockFlowFile flowFile = flowFiles.get(0);
-        String data = new String(flowFile.getData());
+        MockFlowFile successFlowFile = successFlowFiles.get(0);
+        String data = new String(successFlowFile.getData());
         assertTrue("HL7 data not converted correctly", data != null && data.startsWith("{"));
+
+        successFlowFile.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), HL7ToFhirProcessor.APPLICATION_JSON);
         
-        flowFile.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), HL7ToFhirProcessor.APPLICATION_JSON);
+        // Validate Fail Relationship
+        List<MockFlowFile> failFlowFiles = testRunner.getFlowFilesForRelationship(HL7ToFhirProcessor.FAIL_RELATIONSHIP);
+        assertTrue("Failed Flow Files returned on unexpectedly", failFlowFiles == null || failFlowFiles.size() == 0);
+
+        // Validate HL7 Not Detected Relationship
+        List<MockFlowFile> notHL7FlowFiles = testRunner.getFlowFilesForRelationship(HL7ToFhirProcessor.HL7_NOT_DETECTED_RELATIONSHIP);
+        assertTrue("HL7 Not Detected Flow Files returned unexpectedly", notHL7FlowFiles == null || notHL7FlowFiles.size() == 0);
+    }
+
+    @Test
+    public void testBadHL7Data() {
+      String content = "";
+        // Add the content to the runner
+        testRunner.enqueue(content);
+
+        // Run the enqueued content, it also takes an int = number of contents queued
+        testRunner.run(1);
+
+        // All results were processed with out failure
+        testRunner.assertQueueEmpty();
+
+        List<MockFlowFile> successFlowFiles = testRunner.getFlowFilesForRelationship(HL7ToFhirProcessor.SUCCESS_RELATIONSHIP);
+        List<MockFlowFile> failFlowFiles = testRunner.getFlowFilesForRelationship(HL7ToFhirProcessor.FAIL_RELATIONSHIP);
+        List<MockFlowFile> notHL7FlowFiles = testRunner.getFlowFilesForRelationship(HL7ToFhirProcessor.HL7_NOT_DETECTED_RELATIONSHIP);
+        
+        // Validate Success Relationship
+        assertTrue("Successful Flow Files returned unexpectedly", successFlowFiles == null || successFlowFiles.size() == 0);
+                
+        // Validate Fail Relationship
+        assertTrue("No Flow Files returned on failure relationship", failFlowFiles != null && failFlowFiles.size() == 1);
+
+        // Validate HL7 Not Detected Relationship
+        assertTrue("HL7 Not Detected Flow Files returned unexpectedly", notHL7FlowFiles == null || notHL7FlowFiles.size() == 0);
+    }
+
+    @Test
+    public void testNotHL7Data() {
+        String content = "{}";
+        // Add the content to the runner
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(CoreAttributes.MIME_TYPE.key(), HL7ToFhirProcessor.APPLICATION_JSON);
+        testRunner.enqueue(content, attributes);
+
+        // Run the enqueued content, it also takes an int = number of contents queued
+        testRunner.run(1);
+
+        // All results were processed with out failure
+        testRunner.assertQueueEmpty();
+
+        List<MockFlowFile> successFlowFiles = testRunner.getFlowFilesForRelationship(HL7ToFhirProcessor.SUCCESS_RELATIONSHIP);
+        List<MockFlowFile> failFlowFiles = testRunner.getFlowFilesForRelationship(HL7ToFhirProcessor.FAIL_RELATIONSHIP);
+        List<MockFlowFile> notHL7FlowFiles = testRunner.getFlowFilesForRelationship(HL7ToFhirProcessor.HL7_NOT_DETECTED_RELATIONSHIP);
+        
+        // Validate Success Relationship
+        assertTrue("Successful Flow Files returned unexpectedly", successFlowFiles == null || successFlowFiles.size() == 0);
+        
+        
+        // Validate Fail Relationship
+        assertTrue("Failed Flow Files returned on unexpectedly", failFlowFiles == null || failFlowFiles.size() == 0);
+
+        // Validate HL7 Not Detected Relationship
+        assertTrue("No Flow Files returned on Not HL7 Data relationship", notHL7FlowFiles != null && notHL7FlowFiles.size() == 1);
+        MockFlowFile notHL7FlowFile = notHL7FlowFiles.get(0);
+        String data = new String(notHL7FlowFile.getData());
+        assertTrue("Unconvertable data not returned correctly", data != null && data.equals(content));
+
+        notHL7FlowFile.assertAttributeEquals(CoreAttributes.MIME_TYPE.key(), HL7ToFhirProcessor.APPLICATION_JSON);
     }
 }


### PR DESCRIPTION
Updated processor to use input/output callbacks, and added tests to validate non-success paths.