### PR TITLE
fix request size limit on kafka producer

### DIFF
--- a/services/expose-kafka/exposekafka.py
+++ b/services/expose-kafka/exposekafka.py
@@ -83,7 +83,7 @@ def produce():
 
     post_data = request.data.decode("utf-8")
 
-    producer = KafkaProducer(bootstrap_servers=kafkabootstrap)
+    producer = KafkaProducer(bootstrap_servers=kafkabootstrap, max_request_size=10000000)
 
     producer.send(topic, value=bytes(post_data, 'utf-8'), headers=headers)
     producer.flush()


### PR DESCRIPTION
Increases the default request size limit for kafka producer within the expose-kafka service.