### PR TITLE
Fix callback usage

### DIFF
--- a/cohort-service/pom.xml
+++ b/cohort-service/pom.xml
@@ -16,6 +16,7 @@
         <opentracing-spring-jaeger-web-starter.version>3.1.1</opentracing-spring-jaeger-web-starter.version>
         <app.name>cohort-service</app.name>
         <hapi.fhir.version>5.2.0</hapi.fhir.version>
+        <cqframework.version>1.5.1</cqframework.version>
     </properties>
 
     <parent>
@@ -23,6 +24,41 @@
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>2.3.4.RELEASE</version>
     </parent>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>info.cqframework</groupId>
+                <artifactId>cql-to-elm</artifactId>
+                <version>${cqframework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>info.cqframework</groupId>
+                <artifactId>elm</artifactId>
+                <version>${cqframework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>info.cqframework</groupId>
+                <artifactId>cql</artifactId>
+                <version>${cqframework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>info.cqframework</groupId>
+                <artifactId>model</artifactId>
+                <version>${cqframework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>info.cqframework</groupId>
+                <artifactId>quick</artifactId>
+                <version>${cqframework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>info.cqframework</groupId>
+                <artifactId>qdm</artifactId>
+                <version>${cqframework.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <!-- Core -->
@@ -74,7 +110,13 @@
         	<groupId>com.ibm.cohort</groupId>
         	<artifactId>cohort-engine</artifactId>
         	<!-- This is a fixed version from the Cohort Team's SNAPSHOTs that we are currently using that we got from Corey Snders. -->
-        	<version>0.0.1-SNAPSHOT</version>
+            <version>0.0.1-20210803.165707-125</version>
+        </dependency>
+        <dependency>
+        	<groupId>com.ibm.cohort</groupId>
+        	<artifactId>cohort-util</artifactId>
+        	<!-- This is a fixed version from the Cohort Team's SNAPSHOTs that we are currently using that we got from Corey Snders. -->
+            <version>0.0.1-20210803.165339-105</version>
         </dependency>
 
 	    <dependency>
@@ -120,6 +162,28 @@
     </build>
 
 	<repositories>
+		<repository>
+			<id>cql.releases</id>
+			<name>CQL Framework and Engine Releases</name>
+			<url>https://oss.sonatype.org/content/repositories/releases</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+		<repository>
+			<id>cql.snapshots</id>
+			<name>CQL Framework and Engine Snapshots</name>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
  		<repository>
 			<id>github</id>
 			<name>GitHub Alvearie Cohort Service Dependencies</name>

--- a/cohort-service/src/main/java/com/ibm/healthpatterns/app/CohortService.java
+++ b/cohort-service/src/main/java/com/ibm/healthpatterns/app/CohortService.java
@@ -42,6 +42,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ibm.cohort.engine.CqlEvaluator;
 import com.ibm.cohort.engine.DirectoryLibrarySourceProvider;
+import com.ibm.cohort.engine.LoggingEnum;
 import com.ibm.cohort.engine.MultiFormatLibrarySourceProvider;
 import com.ibm.cohort.engine.TranslatingLibraryLoader;
 import com.ibm.cohort.translator.provider.CqlTranslationProvider;
@@ -341,7 +342,7 @@ public class CohortService {
 		// TODO: Add support for parameters
 		// parameters = parseParameterArguments(arguments.parameters);
 		try {
-			cqlEngine.evaluate(cql.getName(), cql.getVersion(), null, null, patientIds, new CQLExecutionCallback(cohort, reverseMatch));
+			cqlEngine.evaluate(cql.getName(), cql.getVersion(), null, null, patientIds, LoggingEnum.NA, new CQLExecutionCallback(cohort, reverseMatch));
 		} catch (Exception e) {
 			throw new CQLExecutionException(e);
 		}

--- a/cohort-service/src/main/java/com/ibm/healthpatterns/app/CohortService.java
+++ b/cohort-service/src/main/java/com/ibm/healthpatterns/app/CohortService.java
@@ -44,8 +44,8 @@ import com.ibm.cohort.engine.CqlEvaluator;
 import com.ibm.cohort.engine.DirectoryLibrarySourceProvider;
 import com.ibm.cohort.engine.MultiFormatLibrarySourceProvider;
 import com.ibm.cohort.engine.TranslatingLibraryLoader;
-import com.ibm.cohort.engine.translation.CqlTranslationProvider;
-import com.ibm.cohort.engine.translation.InJVMCqlTranslationProvider;
+import com.ibm.cohort.translator.provider.CqlTranslationProvider;
+import com.ibm.cohort.translator.provider.InJVMCqlTranslationProvider;
 import com.ibm.cohort.fhir.client.config.FhirClientBuilder;
 import com.ibm.cohort.fhir.client.config.FhirClientBuilderFactory;
 import com.ibm.cohort.fhir.client.config.FhirServerConfig;
@@ -287,6 +287,7 @@ public class CohortService {
 		// We persist the library for the next time the service starts
 		Files.copy(new ByteArrayInputStream(cql.getBytes()), path, StandardCopyOption.REPLACE_EXISTING);
 		cqls.put(cqlFile.toString(), cqlFile);
+		resetCQLDirectory();
 		return cqlFile;
 	}
 


### PR DESCRIPTION
There are two types of callbacks available to clients using the
CQLEvaluator. One is a legacy callback that only exposes expression
complete events and the other is a newer API that exposes context
begin/end events in addition to expresion complete events. The
CohortService code was using an API that accepts the legacy callback,
but passing a modern callback. CqlEvaluator will wrap a legacy callback
in a modern callback proxy and noop the context begin/end events in
those cases. CohortService needs the context begin/end events, so I
updated the code to use the the correct API call for an
EvaluationResultCallback.