### PR TITLE
Add ingest tests to health-patterns repo toolchain

### DIFF
--- a/clinical-enrichment/tests/tests/run-fvttests.sh
+++ b/clinical-enrichment/tests/tests/run-fvttests.sh
@@ -90,10 +90,10 @@ then
 
    # JUNIT execution reports available in the below folder
    ls -lrt target/surefire-reports
-   cat target/surefire-reports/integration.categories.BasicIngestionInitTests.txt
-   cat target/surefire-reports/integration.categories.BasicIngestionTests.txt
-   cat target/surefire-reports/integration.categories.DeIDIngestionTests.txt
-   cat target/surefire-reports/integration.categories.ASCVDIngestionTests.txt
+   cat target/surefire-reports/categories.BasicIngestionInitTests.txt
+   cat target/surefire-reports/categories.BasicIngestionTests.txt
+   cat target/surefire-reports/categories.DeIDIngestionTests.txt
+   cat target/surefire-reports/categories.ASCVDIngestionTests.txt
 
 fi
 

--- a/clinical-enrichment/tests/tests/run-fvttests.sh
+++ b/clinical-enrichment/tests/tests/run-fvttests.sh
@@ -8,11 +8,11 @@
 chmod +x ./tests/toolchain-envsetup.sh
 source ./tests/toolchain-envsetup.sh "fvt"
 
-echo " change to the correct directory"
+echo " change to the correct deployment directory"
 cd /workspace/$TEST_NAMESPACE/health-patterns/helm-charts/health-patterns
 
 # Execute the desired deployment
-echo $CLUSTER_NAMESPACE" : Deploy via helm3"
+echo $TEST_NAMESPACE" : Deploy via helm3"
 if [ $CLUSTER_NAMESPACE = "clinical-enrich" ] 
 then
    # deploy enrich
@@ -24,7 +24,7 @@ then
 fi
 
 echo "*************************************"
-echo "* Waiting for "$deploywait" seconds             *"
+echo "* Waiting for "$deploywait" seconds           *"
 echo "*************************************"
 date
 sleep $deploywait  

--- a/clinical-enrichment/tests/tests/run-fvttests.sh
+++ b/clinical-enrichment/tests/tests/run-fvttests.sh
@@ -1,186 +1,101 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
-# Run the Avlearie Clinical Enrichment Deploy install per documented instructions
+# Run the Avlearie enrich/ingestion Deploy install per documented instructions (selection based on CLUSER_NAMESPACE from toolchain input
 #
-# Run the Clinical Enrichment smoke tests and add test results to fvttest.xml for the Insights Quality Dashboard
+# Run the enrich/ingestion FVT and add test results to fvttest.xml for the Insights Quality Dashboard
 
-echo "*************************************"
-echo "* Linux version                     *"
-echo "*************************************"
-cat /etc/redhat-release
-
-echo "*************************************"
-echo "* Current Directory                 *"
-echo "*************************************"
-pwd
-  
-#echo "*************************************"
-#echo "* Install OpenJDK 11                *"
-#echo "*************************************"
-#wget --quiet https://download.java.net/openjdk/jdk11/ri/openjdk-11+28_linux-x64_bin.tar.gz
-#tar -xf openjdk-11+28_linux-x64_bin.tar.gz
-#sudo mv jdk-14.0.2 /usr/lib/jvm
-
-#ls /usr/lib/jvm
-
-echo "*************************************"
-echo "* Set Test env variables            *"
-echo "*************************************"
-export DEFAULT_PASSWORD=integrati0n
-export JAVA_HOME=/usr/lib/jvm/java-1.8.0
-export HELM_RELEASE=enrich
-export TEST_NAMESPACE=$CLUSTER_NAMESPACE"-fvt"
-#This is for VPC cluster health-patterns-1
-export INGRESS_SUBDOMAIN=wh-health-patterns.dev.watson-health.ibm.com
-#export JAVA_TOOL_OPTIONS=-Dhttps.protocols=TLSv1.3 
-
-echo "*************************************"
-echo "* setup base directory for test     *"
-echo "*************************************"
-cd /workspace
-mkdir $TEST_NAMESPACE
-cd $TEST_NAMESPACE
-
-echo "*************************************"
-echo "* create namespace and set to it    *"
-echo "*************************************"
-kubectl create namespace $TEST_NAMESPACE
-
-echo " Set namespace to $TEST_NAMESPACE"
-kubectl config set-context --current --namespace=$TEST_NAMESPACE
-
-echo "*************************************"
-echo "* Clinical Ingestion Deploy         *"
-echo "*************************************"
-
-echo " clone clinical ingestion git repo using "$GIT_BRANCH " branch"
-git clone --branch $GIT_BRANCH https://github.com/Alvearie/health-patterns.git
+# Setup the test environment
+chmod +x ./tests/toolchain-envsetup.sh
+source ./tests/toolchain-envsetup.sh "fvt"
 
 echo " change to the correct directory"
-cd health-patterns/helm-charts/health-patterns
+cd /workspace/$TEST_NAMESPACE/health-patterns/helm-charts/health-patterns
 
-echo " helm dependency update"
-helm3 dependency update
+# Execute the desired deployment
+echo $CLUSTER_NAMESPACE" : Deploy via helm3"
+if [ $CLUSTER_NAMESPACE = "clinical-enrich" ] 
+then
+   # deploy enrich
+   helm3 install $HELM_RELEASE . -f clinical_enrichment.yaml --set ascvd-from-fhir.ingress.enabled=true --set deid-prep.ingress.enabled=true --set term-services-prep.ingress.enabled=true --set nlp-insights.enabled=true --set nlp-insights.ingress.enabled=true --set nlp-insights.nlpservice.quickumls.endpoint=https://quickumls.wh-health-patterns.dev.watson-health.ibm.com/match --set nlp-insights.nlpservice.acd.endpoint=https://us-east.wh-acd.cloud.ibm.com/wh-acd/api --set nlp-insights.nlpservice.acd.apikey=$ACD_APIKEY --set nlp-insights.nlpservice.acd.flow=wh_acd.ibm_clinical_insights_v1.0_standard_flow --wait --timeout 6m0s
+elif [ $CLUSTER_NAMESPACE = "clinical-ingestion" ] 
+then
+   # deploy ingestion
+   helm3 install $HELM_RELEASE . -f de-id-pattern-values.yaml -f clinical_ingestion.yaml --wait --timeout 6m0s
+fi
 
-echo " Current Directory:"
-pwd
-
-# figure out the ingress subdomain and save as INGRESS_SUBDOMAIN
-# This is for non-VPC clusters
-#export INGRESS_SUBDOMAIN=$(ibmcloud ks cluster get --cluster integration-k8s-cluster -json | grep hostname)
-#export INGRESS_SUBDOMAIN=${INGRESS_SUBDOMAIN:21}
-#export INGRESS_SUBDOMAIN=${INGRESS_SUBDOMAIN:0:${#INGRESS_SUBDOMAIN}-2}
-
-# Add hostname to values.yaml
-sed -i -e "s/\&hostname replace-me/\&hostname $TEST_NAMESPACE.$INGRESS_SUBDOMAIN/g" values.yaml
-cat values.yaml | grep $TEST_NAMESPACE.$INGRESS_SUBDOMAIN
- 
-# deploy 
-echo "Deploy via helm3  using Ingress"
-helm3 install $HELM_RELEASE . -f clinical_enrichment.yaml --set ascvd-from-fhir.ingress.enabled=true --set deid-prep.ingress.enabled=true --set term-services-prep.ingress.enabled=true --set nlp-insights.enabled=true --set nlp-insights.ingress.enabled=true --set nlp-insights.nlpservice.quickumls.endpoint=https://quickumls.wh-health-patterns.dev.watson-health.ibm.com/match --set nlp-insights.nlpservice.acd.endpoint=https://us-east.wh-acd.cloud.ibm.com/wh-acd/api --set nlp-insights.nlpservice.acd.apikey=$ACD_APIKEY --set nlp-insights.nlpservice.acd.flow=wh_acd.ibm_clinical_insights_v1.0_standard_flow --wait --timeout 6m0s
-
-# setup all the env vars for input to maven
-# FHIR Using INGRESS
-export FHIR_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/fhir
-export FHIR_PORT=
 echo "*************************************"
-echo FHIR server: $FHIR_IP$FHIR_PORT
-echo "*************************************"
-
-# FHIR DEID - using INGRESS
-export FHIR_DEID_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/fhir-deid
-export FHIR_DEID_PORT=
-echo "*************************************"
-echo FHIR DEID server: $FHIR_DEID_IP$FHIR_DEID_PORT
-echo "*************************************"
-
-# DEID - using INGRESS
-export DEID_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/deid
-export DEID_PORT=
-echo "*************************************"
-echo DEID server: $DEID_IP$DEID_PORT
-echo "*************************************"
-
-# DEID Prep - using INGRESS
-export DEID_PREP_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/deid-prep
-export DEID_PREP_PORT=
-echo "*************************************"
-echo DEID-PREP server: $DEID_PREP_IP$DEID_PREP_PORT
-echo "*************************************"
-
-# TERM Services Prep - using INGRESS
-export TERM_PREP_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/term-services-prep
-export TERM_PREP_PORT=
-echo "*************************************"
-echo TERM-SERVICES-PREP server: $TERM_PREP_IP$TERM_PREP_PORT
-echo "*************************************"
-
-# ASCVD From FHIR Service - using INGRESS
-export ASCVD_FROM_FHIR_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/ascvd-from-fhir
-export ASCVD_FROM_FHIR_PORT=
-echo "*************************************"
-echo ASCVD-FROM-FHIR server: $ASCVD_FROM_FHIR_IP$ASCVD_FROM_FHIR_PORT
-echo "*************************************"
-
-# NLP Insights Service - using INGRESS
-export NLP_INSIGHTS_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/nlp-insights
-export NLP_INSIGHTS_PORT=
-echo "*************************************"
-echo NLP Insights server: $NLP_INSIGHTS_IP$NLP_INSIGHTS_PORT
-echo "*************************************"
-
-# Wait a bit for Nifi to come up
-# Need to change this to some polling of service status for more reliability 
-echo "*************************************"
-echo "* Waiting for 2 minutes             *"
+echo "* Waiting for "$deploywait" seconds             *"
 echo "*************************************"
 date
-sleep 120  
+sleep $deploywait  
 date
-
-# KAFKA - using Load Balancer
-export KAFKA_IP=$(kubectl get svc --namespace $TEST_NAMESPACE $HELM_RELEASE-kafka-0-external -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
-export KAFKA_PORT=:$(kubectl get svc $HELM_RELEASE-kafka-0-external -o jsonpath='{.spec.ports[0].port}') 
-echo KAFKA server: $KAFKA_IP$KAFKA_PORT
 
 echo "*************************************" 
 echo "* A Look At Everything              *"
 echo "*************************************"
 kubectl get all
 
-echo "****************************************************" 
-echo "* Goto the testcase folder in the repo             *"
-echo "****************************************************"
-cd /workspace/$TEST_NAMESPACE/health-patterns/clinical-enrichment/
-pwd
-ls
+if [ $CLUSTER_NAMESPACE = "clinical-enrich" ]  
+then 
 
-echo "*************************************" 
-echo "* Build the testcases               *"
-echo "*************************************"
-mvn clean install -e -Dip.fhir=$FHIR_IP -Dport.fhir=$FHIR_PORT -Dip.fhir.deid=$FHIR_DEID_IP -Dport.fhir.deid=$FHIR_DEID_PORT -Dip.deid.prep=$DEID_PREP_IP -Dport.deid.prep=$DEID_PREP_PORT -Dip.term.prep=$TERM_PREP_IP -Dport.term.prep=$TERM_PREP_PORT -Dip.ascvd.from.fhir=$ASCVD_FROM_FHIR_IP -Dport.ascvd.from.fhir=$ASCVD_FROM_FHIR_PORT -Dip.nlp.insights=$NLP_INSIGHTS_IP -Dport.nlp.insights=$NLP_INSIGHTS_PORT -Dpw=$DEFAULT_PASSWORD
+   echo "****************************************************" 
+   echo "* Goto the testcase folder in the repo             *"
+   echo "****************************************************"
+   cd /workspace/$TEST_NAMESPACE/health-patterns/clinical-enrichment/
 
-echo "*************************************" 
-echo "* Properties File:                  *"
-echo "*************************************"
-cat src/test/resources/enrich-flow.properties
+   echo "*************************************" 
+   echo "* Build the testcases               *"
+   echo "*************************************"
+   mvn clean install -e -Dip.fhir=$FHIR_IP -Dport.fhir=$FHIR_PORT -Dip.fhir.deid=$FHIR_DEID_IP -Dport.fhir.deid=$FHIR_DEID_PORT -Dip.deid.prep=$DEID_PREP_IP -Dport.deid.prep=$DEID_PREP_PORT -Dip.term.prep=$TERM_PREP_IP -Dport.term.prep=$TERM_PREP_PORT -Dip.ascvd.from.fhir=$ASCVD_FROM_FHIR_IP -Dport.ascvd.from.fhir=$ASCVD_FROM_FHIR_PORT -Dip.nlp.insights=$NLP_INSIGHTS_IP -Dport.nlp.insights=$NLP_INSIGHTS_PORT -Dpw=$DEFAULT_PASSWORD
 
+   echo "*************************************" 
+   echo "* Execute the testcases             *"
+   echo "*************************************"
+   mvn -e -DskipTests=false -Dtest=EnrichmentInitTests test
+   mvn -e -DskipTests=false -Dtest=BasicEnrichmentTests test
+   mvn -e -DskipTests=false -Dtest=EnrichmentConfigTests test
+   mvn -e -DskipTests=false -Dtest=ASCVDEnrichmentTests test
 
+   # JUNIT execution reports available in the below folder
+   ls -lrt target/surefire-reports
+   cat target/surefire-reports/categories.EnrichmentInitTests.txt
+   cat target/surefire-reports/categories.BasicEnrichmentTests.txt
+   cat target/surefire-reports/categories.EnrichmentConfigTests.txt
+   cat target/surefire-reports/categories.ASCVDEnrichmentTests.txt
+   
+elif [ $CLUSTER_NAMESPACE = "clinical-ingestion" ] 
+then
 
-echo "*************************************" 
-echo "* Execute the testcases             *"
-echo "*************************************"
-mvn -e -DskipTests=false -Dtest=EnrichmentInitTests test
-mvn -e -DskipTests=false -Dtest=BasicEnrichmentTests test
-mvn -e -DskipTests=false -Dtest=EnrichmentConfigTests test
-mvn -e -DskipTests=false -Dtest=ASCVDEnrichmentTests test
+   echo "****************************************************" 
+   echo "* Goto the testcase folder in the repo             *"
+   echo "****************************************************"
+   cd /workspace/$TEST_NAMESPACE/health-patterns/ingest/
 
-# JUNIT execution reports available in the below folder
-ls -lrt target/surefire-reports
-cat target/surefire-reports/categories.EnrichmentInitTests.txt
-cat target/surefire-reports/categories.BasicEnrichmentTests.txt
-cat target/surefire-reports/categories.EnrichmentConfigTests.txt
-cat target/surefire-reports/categories.ASCVDEnrichmentTests.txt
+   echo "*************************************" 
+   echo "* Build the testcases               *"
+   echo "*************************************"
+   mvn clean install -e -Dip.fhir=$FHIR_IP -Dport.fhir=$FHIR_PORT -Dip.fhir.deid=$FHIR_DEID_IP -Dport.fhir.deid=$FHIR_DEID_PORT -Dip.nifi=$NIFI_IP -Dport.nifi=$NIFI_PORT -Dip.nifi.api=$NIFI_API_IP -Dport.nifi.api=$NIFI_API_PORT -Dip.kafka=$KAFKA_IP -Dport.nifi.api=$NIFI_API_PORT -Dip.deid=$DEID_IP -Dport.deid=$DEID_PORT -Dip.expkafka=$EXP_KAFKA_IP -Dport.expkafka=$EXP_KAFKA_PORT -Dpw=$DEFAULT_PASSWORD
+
+   echo "*************************************" 
+   echo "* Execute the initialize testcases  *"
+   echo "*************************************"
+   mvn -e -DskipTests=false -Dtest=BasicIngestionInitTests test
+
+   echo "*************************************" 
+   echo "* Execute the testcases             *"
+   echo "*************************************"
+   mvn  -e  -DskipTests=false -Dtest=BasicIngestionTests test
+   mvn  -e  -DskipTests=false -Dtest=DeIDIngestionTests test
+   mvn  -e  -DskipTests=false -Dtest=ASCVDIngestionTests test
+
+   # JUNIT execution reports available in the below folder
+   ls -lrt target/surefire-reports
+   cat target/surefire-reports/integration.categories.BasicIngestionInitTests.txt
+   cat target/surefire-reports/integration.categories.BasicIngestionTests.txt
+   cat target/surefire-reports/integration.categories.DeIDIngestionTests.txt
+   cat target/surefire-reports/integration.categories.ASCVDIngestionTests.txt
+
+fi
 
 echo "*************************************" 
 echo "* Report Test Results to Insights   *"

--- a/clinical-enrichment/tests/tests/run-ivttests.sh
+++ b/clinical-enrichment/tests/tests/run-ivttests.sh
@@ -8,11 +8,11 @@
 chmod +x ./tests/toolchain-envsetup.sh
 source ./tests/toolchain-envsetup.sh "ivt"
 
-echo " change to the correct directory"
+echo " change to the correct deployment directory"
 cd /workspace/$TEST_NAMESPACE/health-patterns/helm-charts/health-patterns
 
 # Execute the desired deployment
-echo $CLUSTER_NAMESPACE" : Deploy via helm3"
+echo $TEST_NAMESPACE" : Deploy via helm3"
 if [ $CLUSTER_NAMESPACE = "clinical-enrich" ] 
 then
   # deploy enrich
@@ -25,7 +25,7 @@ fi
 
 
 echo "*************************************"
-echo "* Waiting for "$deploywait" seconds             *"
+echo "* Waiting for "$deploywait" seconds           *"
 echo "*************************************"
 date
 sleep $deploywait  

--- a/clinical-enrichment/tests/tests/run-ivttests.sh
+++ b/clinical-enrichment/tests/tests/run-ivttests.sh
@@ -94,12 +94,12 @@ then
 
    # JUNIT execution reports available in the below folder
    ls -lrt target/surefire-reports
-   cat target/surefire-reports/integration.categories.BasicIngestionInitTests.txt
-   cat target/surefire-reports/integration.categories.FHIRProxyIngestionTests.txt
-   cat target/surefire-reports/integration.categories.BasicIngestionTests.txt
-   cat target/surefire-reports/integration.categories.DeIDIngestionTests.txt
-   cat target/surefire-reports/integration.categories.ASCVDIngestionTests.txt
-   cat target/surefire-reports/integration.categories.NLPIngestionTests.txt
+   cat target/surefire-reports/categories.BasicIngestionInitTests.txt
+   cat target/surefire-reports/categories.FHIRProxyIngestionTests.txt
+   cat target/surefire-reports/categories.BasicIngestionTests.txt
+   cat target/surefire-reports/categories.DeIDIngestionTests.txt
+   cat target/surefire-reports/categories.ASCVDIngestionTests.txt
+   cat target/surefire-reports/categories.NLPIngestionTests.txt
    
 fi   
 echo "*************************************" 

--- a/clinical-enrichment/tests/tests/run-ivttests.sh
+++ b/clinical-enrichment/tests/tests/run-ivttests.sh
@@ -1,187 +1,107 @@
 #!/usr/bin/env bash
 
-# Run the Avlearie Clinical Enrichment Deploy install per documented instructions
+# Run the Avlearie enrich/ingestion Deploy install per documented instructions (selection based on CLUSER_NAMESPACE from toolchain input
 #
-# Run the Clinical Enrichment smoke tests and add test results to ivttest.xml for the Insights Quality Dashboard
+# Run the enrich/ingestion smoke tests and add test results to ivttests.xml for the Insights Quality Dashboard
 
-echo "*************************************"
-echo "* Linux version                     *"
-echo "*************************************"
-cat /etc/redhat-release
-
-echo "*************************************"
-echo "* Current Directory                 *"
-echo "*************************************"
-pwd
-  
-#echo "*************************************"
-#echo "* Install OpenJDK 11                *"
-#echo "*************************************"
-#wget --quiet https://download.java.net/openjdk/jdk11/ri/openjdk-11+28_linux-x64_bin.tar.gz
-#tar -xf openjdk-11+28_linux-x64_bin.tar.gz
-#sudo mv jdk-14.0.2 /usr/lib/jvm
-
-#ls /usr/lib/jvm
-
-echo "*************************************"
-echo "* Set Test env variables            *"
-echo "*************************************"
-export DEFAULT_PASSWORD=integrati0n
-export JAVA_HOME=/usr/lib/jvm/java-1.8.0
-export HELM_RELEASE=enrich
-export TEST_NAMESPACE=$CLUSTER_NAMESPACE"-ivt"
-#This is for VPC cluster health-patterns-1
-export INGRESS_SUBDOMAIN=wh-health-patterns.dev.watson-health.ibm.com
-#export JAVA_TOOL_OPTIONS=-Dhttps.protocols=TLSv1.3 
-
-echo "*************************************"
-echo "* setup base directory for test     *"
-echo "*************************************"
-cd /workspace
-mkdir $TEST_NAMESPACE
-cd $TEST_NAMESPACE
-
-echo "*************************************"
-echo "* create namespace and set to it    *"
-echo "*************************************"
-kubectl create namespace $TEST_NAMESPACE
-
-echo " Set namespace to $TEST_NAMESPACE"
-kubectl config set-context --current --namespace=$TEST_NAMESPACE
-
-echo "*************************************"
-echo "* Clinical Ingestion Deploy         *"
-echo "*************************************"
-
-echo " clone clinical ingestion git repo using "$GIT_BRANCH " branch"
-git clone --branch $GIT_BRANCH https://github.com/Alvearie/health-patterns.git
+# Setup the test environment
+chmod +x ./tests/toolchain-envsetup.sh
+source ./tests/toolchain-envsetup.sh "ivt"
 
 echo " change to the correct directory"
-cd health-patterns/helm-charts/health-patterns
+cd /workspace/$TEST_NAMESPACE/health-patterns/helm-charts/health-patterns
 
-echo " helm dependency update"
-helm3 dependency update
+# Execute the desired deployment
+echo $CLUSTER_NAMESPACE" : Deploy via helm3"
+if [ $CLUSTER_NAMESPACE = "clinical-enrich" ] 
+then
+  # deploy enrich
+  helm3 install $HELM_RELEASE . -f clinical_enrichment.yaml --set ascvd-from-fhir.ingress.enabled=true --set deid-prep.ingress.enabled=true --set term-services-prep.ingress.enabled=true --set nlp-insights.enabled=true --set nlp-insights.ingress.enabled=true --set nlp-insights.nlpservice.quickumls.endpoint=https://quickumls.wh-health-patterns.dev.watson-health.ibm.com/match --set nlp-insights.nlpservice.acd.endpoint=https://us-east.wh-acd.cloud.ibm.com/wh-acd/api --set nlp-insights.nlpservice.acd.apikey=$ACD_APIKEY --set nlp-insights.nlpservice.acd.flow=wh_acd.ibm_clinical_insights_v1.0_standard_flow --wait --timeout 6m0s
+elif [ $CLUSTER_NAMESPACE = "clinical-ingestion" ] 
+then
+   # deploy ingestion
+   helm3 install $HELM_RELEASE . -f de-id-pattern-values.yaml -f clinical_ingestion.yaml --set fhir.proxy.enabled=true --set fhir-deid.proxy.enabled=true --set nlp-insights.enabled=true --set nlp-insights.nlpservice.quickumls.endpoint=https://quickumls.wh-health-patterns.dev.watson-health.ibm.com/match --wait --timeout 6m0s
+fi
 
-echo " Current Directory:"
-pwd
 
-# figure out the ingress subdomain and save as INGRESS_SUBDOMAIN
-# This is for non-VPC clusters
-#export INGRESS_SUBDOMAIN=$(ibmcloud ks cluster get --cluster integration-k8s-cluster -json | grep hostname)
-#export INGRESS_SUBDOMAIN=${INGRESS_SUBDOMAIN:21}
-#export INGRESS_SUBDOMAIN=${INGRESS_SUBDOMAIN:0:${#INGRESS_SUBDOMAIN}-2}
-
-# Add hostname to values.yaml
-sed -i -e "s/\&hostname replace-me/\&hostname $TEST_NAMESPACE.$INGRESS_SUBDOMAIN/g" values.yaml
-cat values.yaml | grep $TEST_NAMESPACE.$INGRESS_SUBDOMAIN
-  
-# deploy 
-echo "Deploy via helm3  using Ingress"
-helm3 install $HELM_RELEASE . -f clinical_enrichment.yaml --set ascvd-from-fhir.ingress.enabled=true --set deid-prep.ingress.enabled=true --set term-services-prep.ingress.enabled=true --set nlp-insights.enabled=true --set nlp-insights.ingress.enabled=true --set nlp-insights.nlpservice.quickumls.endpoint=https://quickumls.wh-health-patterns.dev.watson-health.ibm.com/match --set nlp-insights.nlpservice.acd.endpoint=https://us-east.wh-acd.cloud.ibm.com/wh-acd/api --set nlp-insights.nlpservice.acd.apikey=$ACD_APIKEY --set nlp-insights.nlpservice.acd.flow=wh_acd.ibm_clinical_insights_v1.0_standard_flow --wait --timeout 6m0s
-
-# setup all the env vars for input to maven
-# FHIR Using INGRESS
-export FHIR_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/fhir
-export FHIR_PORT=
 echo "*************************************"
-echo FHIR server: $FHIR_IP$FHIR_PORT
-echo "*************************************"
-
-# FHIR DEID - using INGRESS
-export FHIR_DEID_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/fhir-deid
-export FHIR_DEID_PORT=
-echo "*************************************"
-echo FHIR DEID server: $FHIR_DEID_IP$FHIR_DEID_PORT
-echo "*************************************"
-
-# DEID - using INGRESS
-export DEID_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/deid
-export DEID_PORT=
-echo "*************************************"
-echo DEID server: $DEID_IP$DEID_PORT
-echo "*************************************"
-
-# DEID Prep - using INGRESS
-export DEID_PREP_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/deid-prep
-export DEID_PREP_PORT=
-echo "*************************************"
-echo DEID-PREP server: $DEID_PREP_IP$DEID_PREP_PORT
-echo "*************************************"
-
-# TERM Services Prep - using INGRESS
-export TERM_PREP_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/term-services-prep
-export TERM_PREP_PORT=
-echo "*************************************"
-echo TERM-SERVICES-PREP server: $TERM_PREP_IP$TERM_PREP_PORT
-echo "*************************************"
-
-# ASCVD From FHIR Service - using INGRESS
-export ASCVD_FROM_FHIR_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/ascvd-from-fhir
-export ASCVD_FROM_FHIR_PORT=
-echo "*************************************"
-echo ASCVD-FROM-FHIR server: $ASCVD_FROM_FHIR_IP$ASCVD_FROM_FHIR_PORT
-echo "*************************************"
-
-# NLP Insights Service - using INGRESS
-export NLP_INSIGHTS_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/nlp-insights
-export NLP_INSIGHTS_PORT=
-echo "*************************************"
-echo NLP Insights server: $NLP_INSIGHTS_IP$NLP_INSIGHTS_PORT
-echo "*************************************"
-
-# Wait a bit for Nifi to come up
-# Need to change this to some polling of service status for more reliability 
-echo "*************************************"
-echo "* Waiting for 2 minutes             *"
+echo "* Waiting for "$deploywait" seconds             *"
 echo "*************************************"
 date
-sleep 120  
+sleep $deploywait  
 date
-
-# KAFKA - using Load Balancer
-export KAFKA_IP=$(kubectl get svc --namespace $TEST_NAMESPACE $HELM_RELEASE-kafka-0-external -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
-export KAFKA_PORT=:$(kubectl get svc $HELM_RELEASE-kafka-0-external -o jsonpath='{.spec.ports[0].port}') 
-echo KAFKA server: $KAFKA_IP$KAFKA_PORT
 
 echo "*************************************" 
 echo "* A Look At Everything              *"
 echo "*************************************"
 kubectl get all
 
-echo "****************************************************" 
-echo "* Goto the testcase folder in the repo             *"
-echo "****************************************************"
-cd /workspace/$TEST_NAMESPACE/health-patterns/clinical-enrichment/
-pwd
-ls
 
-echo "*************************************" 
-echo "* Build the testcases               *"
-echo "*************************************"
-mvn clean install -e -Dip.fhir=$FHIR_IP -Dport.fhir=$FHIR_PORT -Dip.fhir.deid=$FHIR_DEID_IP -Dport.fhir.deid=$FHIR_DEID_PORT -Dip.deid.prep=$DEID_PREP_IP -Dport.deid.prep=$DEID_PREP_PORT -Dip.term.prep=$TERM_PREP_IP -Dport.term.prep=$TERM_PREP_PORT -Dip.ascvd.from.fhir=$ASCVD_FROM_FHIR_IP -Dport.ascvd.from.fhir=$ASCVD_FROM_FHIR_PORT -Dip.nlp.insights=$NLP_INSIGHTS_IP -Dport.nlp.insights=$NLP_INSIGHTS_PORT -Dpw=$DEFAULT_PASSWORD
+if [ $CLUSTER_NAMESPACE = "clinical-enrich" ]  
+then
 
-echo "*************************************" 
-echo "* Properties File:                  *"
-echo "*************************************"
-cat src/test/resources/enrich-flow.properties
+   echo "****************************************************" 
+   echo "* Goto the testcase folder in the repo             *"
+   echo "****************************************************"
+   cd /workspace/$TEST_NAMESPACE/health-patterns/clinical-enrichment/
 
+   echo "*************************************" 
+   echo "* Build the testcases               *"
+   echo "*************************************"
+   mvn clean install -e -Dip.fhir=$FHIR_IP -Dport.fhir=$FHIR_PORT -Dip.fhir.deid=$FHIR_DEID_IP -Dport.fhir.deid=$FHIR_DEID_PORT -Dip.deid.prep=$DEID_PREP_IP -Dport.deid.prep=$DEID_PREP_PORT -Dip.term.prep=$TERM_PREP_IP -Dport.term.prep=$TERM_PREP_PORT -Dip.ascvd.from.fhir=$ASCVD_FROM_FHIR_IP -Dport.ascvd.from.fhir=$ASCVD_FROM_FHIR_PORT -Dip.nlp.insights=$NLP_INSIGHTS_IP -Dport.nlp.insights=$NLP_INSIGHTS_PORT -Dpw=$DEFAULT_PASSWORD
 
+   echo "*************************************" 
+   echo "* Execute the testcases             *"
+   echo "*************************************"
+   mvn -e -DskipTests=false -Dtest=EnrichmentInitTests test
+   mvn -e -DskipTests=false -Dtest=BasicEnrichmentTests test
+   mvn -e -DskipTests=false -Dtest=EnrichmentConfigTests test
+   mvn -e -DskipTests=false -Dtest=ASCVDEnrichmentTests test
 
-echo "*************************************" 
-echo "* Execute the testcases             *"
-echo "*************************************"
-mvn -e -DskipTests=false -Dtest=EnrichmentInitTests test
-mvn -e -DskipTests=false -Dtest=BasicEnrichmentTests test
-mvn -e -DskipTests=false -Dtest=EnrichmentConfigTests test
-mvn -e -DskipTests=false -Dtest=ASCVDEnrichmentTests test
+   # JUNIT execution reports available in the below folder
+   ls -lrt target/surefire-reports
+   cat target/surefire-reports/categories.EnrichmentInitTests.txt
+   cat target/surefire-reports/categories.BasicEnrichmentTests.txt
+   cat target/surefire-reports/categories.EnrichmentConfigTests.txt
+   cat target/surefire-reports/categories.ASCVDEnrichmentTests.txt
 
-# JUNIT execution reports available in the below folder
-ls -lrt target/surefire-reports
-cat target/surefire-reports/categories.EnrichmentInitTests.txt
-cat target/surefire-reports/categories.BasicEnrichmentTests.txt
-cat target/surefire-reports/categories.EnrichmentConfigTests.txt
-cat target/surefire-reports/categories.ASCVDEnrichmentTests.txt
+elif [ $CLUSTER_NAMESPACE = "clinical-ingestion" ] 
+then
 
+   echo "****************************************************" 
+   echo "* Goto the testcase folder in the repo             *"
+   echo "****************************************************"
+   cd /workspace/$TEST_NAMESPACE/health-patterns/ingest/
+  
+   echo "*************************************" 
+   echo "* Build the testcases               *"
+   echo "*************************************"
+   mvn clean install -e -Dip.fhir=$FHIR_IP -Dport.fhir=$FHIR_PORT -Dip.fhir.proxy=$FHIR_PROXY_IP -Dport.fhir.proxy=$FHIR__PROXY_PORT -Dip.fhir.deid=$FHIR_DEID_IP -Dport.fhir.deid=$FHIR_DEID_PORT -Dip.fhir.deid.proxy=$FHIR_DEID_PROXY_IP -Dport.fhir.deid.proxy=$FHIR_DEID_PROXY_PORT -Dip.deid=$DEID_IP -Dport.deid=$DEID_PORT -Dip.nifi=$NIFI_IP -Dport.nifi=$NIFI_PORT -Dip.expkafka=$EXP_KAFKA_IP -Dport.expkafka=$EXP_KAFKA_PORT -Dpw=$DEFAULT_PASSWORD
+
+   echo "*************************************" 
+   echo "* Initialize the testcases          *"
+   echo "*************************************"
+   mvn -e -DskipTests=false -Dtest=BasicIngestionInitTests test
+
+   echo "*************************************" 
+   echo "* Execute the testcases             *"
+   echo "*************************************"
+   mvn  -e -DskipTests=false -Dtest=FHIRProxyIngestionTests test
+   mvn  -e -DskipTests=false -Dtest=BasicIngestionTests test
+   mvn  -e -DskipTests=false -Dtest=DeIDIngestionTests test
+   mvn  -e -DskipTests=false -Dtest=ASCVDIngestionTests test
+   mvn  -e -DskipTests=false -Dtest=NLPIngestionTests test
+
+   # JUNIT execution reports available in the below folder
+   ls -lrt target/surefire-reports
+   cat target/surefire-reports/integration.categories.BasicIngestionInitTests.txt
+   cat target/surefire-reports/integration.categories.FHIRProxyIngestionTests.txt
+   cat target/surefire-reports/integration.categories.BasicIngestionTests.txt
+   cat target/surefire-reports/integration.categories.DeIDIngestionTests.txt
+   cat target/surefire-reports/integration.categories.ASCVDIngestionTests.txt
+   cat target/surefire-reports/integration.categories.NLPIngestionTests.txt
+   
+fi   
 echo "*************************************" 
 echo "* Report Test Results to Insights   *"
 echo "*************************************"

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -3,9 +3,9 @@
 # Run the Avlearie enrich/ingestion Deploy install per documented instructions (selection based on CLUSER_NAMESPACE from toolchain input
 #
 # Run the enrich/ingestion smoke tests and add test results to smoketests.xml for the Insights Quality Dashboard
-
-chmod +x tests/toolchain_envsetup.sh
-source tests/toolchain_envsetup.sh "-smoke"
+cd tests
+chmod +x toolchain_envsetup.sh
+source ./toolchain_envsetup.sh "-smoke"
 
 echo " change to the correct directory"
 cd /workspace/$TEST_NAMESPACE/health-patterns/helm-charts/health-patterns

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 # Run the Avlearie Clinical Enrichment Deploy install per documented instructions
 #

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -3,14 +3,9 @@
 # Run the Avlearie enrich/ingestion Deploy install per documented instructions (selection based on CLUSER_NAMESPACE from toolchain input
 #
 # Run the enrich/ingestion smoke tests and add test results to smoketests.xml for the Insights Quality Dashboard
-echo "*************************************" 
-echo "* Where are we located?             *"
-echo "*************************************"
-pwd
-cd tests
-ls
-chmod +x toolchain_envsetup.sh
-source ./toolchain_envsetup.sh "-smoke"
+
+chmod +x ./tests/toolchain-envsetup.sh
+source ./tests/toolchain-envsetup.sh "-smoke"
 
 echo " change to the correct directory"
 cd /workspace/$TEST_NAMESPACE/health-patterns/helm-charts/health-patterns

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -24,11 +24,12 @@ export TEST_NAMESPACE=$CLUSTER_NAMESPACE"-smoke"
 export INGRESS_SUBDOMAIN=wh-health-patterns.dev.watson-health.ibm.com
 #export JAVA_TOOL_OPTIONS=-Dhttps.protocols=TLSv1.3 
 
+cnd=$CLUSTER_NAMESPACE
 
-if [$CLUSTER_NAMESPACE -eq "clinical-enrich"]
+if [$cnd -eq "clinical-enrich"]
 then
    export HELM_RELEASE=enrich
-elif [$CLUSTER_NAMESPACE -eq "clinical-ingestion"] 
+elif [$cnd -eq "clinical-ingestion"] 
 then
    export HELM_RELEASE=ingestion
 fi
@@ -69,12 +70,12 @@ pwd
 sed -i -e "s/\&hostname replace-me/\&hostname $TEST_NAMESPACE.$INGRESS_SUBDOMAIN/g" values.yaml
 cat values.yaml | grep $TEST_NAMESPACE.$INGRESS_SUBDOMAIN
 
-if [$CLUSTER_NAMESPACE -eq "clinical-enrich"] 
+if [$cnd -eq "clinical-enrich"] 
 then
    # deploy enrich
    echo "$CLUSTER_NAMESPACE - enrich : Deploy via helm3  using Ingress"
    helm3 install $HELM_RELEASE . -f clinical_enrichment.yaml --set ascvd-from-fhir.ingress.enabled=true --set deid-prep.ingress.enabled=true --set term-services-prep.ingress.enabled=true --set nlp-insights.enabled=true --set nlp-insights.ingress.enabled=true --set nlp-insights.nlpservice.quickumls.endpoint=https://quickumls.wh-health-patterns.dev.watson-health.ibm.com/match --set nlp-insights.nlpservice.acd.endpoint=https://us-east.wh-acd.cloud.ibm.com/wh-acd/api --set nlp-insights.nlpservice.acd.apikey=$ACD_APIKEY --set nlp-insights.nlpservice.acd.flow=wh_acd.ibm_clinical_insights_v1.0_standard_flow --wait --timeout 6m0s
-elif [$CLUSTER_NAMESPACE -eq "clinical-ingestion"] 
+elif [$cnd -eq "clinical-ingestion"] 
 then
    # deploy ingestion
    echo "$CLUSTER_NAMESPACE - ingestion : Deploy via helm3  using Ingress"
@@ -148,7 +149,7 @@ echo NLP Insights server: $NLP_INSIGHTS_IP$NLP_INSIGHTS_PORT
 echo "*************************************"
 
 # Wait for deployment to be ready
-if [$CLUSTER_NAMESPACE -eq "clinical-enrich"] 
+if [$cnd -eq "clinical-enrich"] 
 then 
    echo "*************************************"
    echo "* Waiting for 2 minutes             *"
@@ -156,7 +157,7 @@ then
    date
    sleep 120  
    date   
-elif [$CLUSTER_NAMESPACE -eq "clinical-ingestion"] 
+elif [$cnd -eq "clinical-ingestion"] 
 then 
    echo "*************************************"
    echo "* Waiting for 5 minutes             *"
@@ -171,7 +172,7 @@ echo "* A Look At Everything              *"
 echo "*************************************"
 kubectl get all
 
-if [$CLUSTER_NAMESPACE -eq "clinical-enrich"] 
+if [$cnd -eq "clinical-enrich"] 
 then 
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"
@@ -211,7 +212,7 @@ then
    echo "<testsuites>" > /workspace/clinical-enrichment/tests/smoketests.xml
    cat target/surefire-reports/*.xml >> /workspace/clinical-enrichment/tests/smoketests.xml
    echo "</testsuites>" >> /workspace/clinical-enrichment/tests/smoketests.xml
-elif [$CLUSTER_NAMESPACE -eq "clinical-ingestion"] 
+elif [$cnd -eq "clinical-ingestion"] 
 then
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -3,7 +3,12 @@
 # Run the Avlearie enrich/ingestion Deploy install per documented instructions (selection based on CLUSER_NAMESPACE from toolchain input
 #
 # Run the enrich/ingestion smoke tests and add test results to smoketests.xml for the Insights Quality Dashboard
+echo "*************************************" 
+echo "* Where are we located?             *"
+echo "*************************************"
+pwd
 cd tests
+ls
 chmod +x toolchain_envsetup.sh
 source ./toolchain_envsetup.sh "-smoke"
 

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -3,10 +3,9 @@
 # Run the Avlearie enrich/ingestion Deploy install per documented instructions (selection based on CLUSER_NAMESPACE from toolchain input
 #
 # Run the enrich/ingestion smoke tests and add test results to smoketests.xml for the Insights Quality Dashboard
-pwd
-ls
-chmod +x ./tests/toolchain_envsetup.sh
-source ./tests/toolchain_envsetup.sh "-smoke"
+
+chmod +x tests/toolchain_envsetup.sh
+source tests/toolchain_envsetup.sh "-smoke"
 
 echo " change to the correct directory"
 cd /workspace/$TEST_NAMESPACE/health-patterns/helm-charts/health-patterns

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -13,26 +13,23 @@ echo "*************************************"
 echo "* Current Directory                 *"
 echo "*************************************"
 pwd
-  
-#echo "*************************************"
-#echo "* Install OpenJDK 11                *"
-#echo "*************************************"
-#wget --quiet https://download.java.net/openjdk/jdk11/ri/openjdk-11+28_linux-x64_bin.tar.gz
-#tar -xf openjdk-11+28_linux-x64_bin.tar.gz
-#sudo mv jdk-14.0.2 /usr/lib/jvm
-
-#ls /usr/lib/jvm
 
 echo "*************************************"
 echo "* Set Test env variables            *"
 echo "*************************************"
 export DEFAULT_PASSWORD=integrati0n
 export JAVA_HOME=/usr/lib/jvm/java-1.8.0
-export HELM_RELEASE=enrich
 export TEST_NAMESPACE=$CLUSTER_NAMESPACE"-smoke"
 #This is for VPC cluster health-patterns-1
 export INGRESS_SUBDOMAIN=wh-health-patterns.dev.watson-health.ibm.com
 #export JAVA_TOOL_OPTIONS=-Dhttps.protocols=TLSv1.3 
+
+if $CLUSTER_NAMESPACE="clinical-enrichment" then
+   export HELM_RELEASE=enrich
+elif $CLUSTER_NAMESPACE="clinical-ingestion" then
+   export HELM_RELEASE=ingestion
+fi
+
 
 echo "*************************************"
 echo "* setup base directory for test     *"
@@ -65,20 +62,21 @@ helm3 dependency update
 echo " Current Directory:"
 pwd
 
-# figure out the ingress subdomain and save as INGRESS_SUBDOMAIN
-# This is for non-VPC clusters
-#export INGRESS_SUBDOMAIN=$(ibmcloud ks cluster get --cluster integration-k8s-cluster -json | grep hostname)
-#export INGRESS_SUBDOMAIN=${INGRESS_SUBDOMAIN:21}
-#export INGRESS_SUBDOMAIN=${INGRESS_SUBDOMAIN:0:${#INGRESS_SUBDOMAIN}-2}
-
 # Add hostname to values.yaml
 sed -i -e "s/\&hostname replace-me/\&hostname $TEST_NAMESPACE.$INGRESS_SUBDOMAIN/g" values.yaml
 cat values.yaml | grep $TEST_NAMESPACE.$INGRESS_SUBDOMAIN
- 
 
-# deploy 
-echo "Deploy via helm3  using Ingress"
-helm3 install $HELM_RELEASE . -f clinical_enrichment.yaml --set ascvd-from-fhir.ingress.enabled=true --set deid-prep.ingress.enabled=true --set term-services-prep.ingress.enabled=true --set nlp-insights.enabled=true --set nlp-insights.ingress.enabled=true --set nlp-insights.nlpservice.quickumls.endpoint=https://quickumls.wh-health-patterns.dev.watson-health.ibm.com/match --set nlp-insights.nlpservice.acd.endpoint=https://us-east.wh-acd.cloud.ibm.com/wh-acd/api --set nlp-insights.nlpservice.acd.apikey=$ACD_APIKEY --set nlp-insights.nlpservice.acd.flow=wh_acd.ibm_clinical_insights_v1.0_standard_flow --wait --timeout 6m0s
+if $CLUSTER_NAMESPACE="clinical-enrichment" then
+   # deploy enrich
+   echo "$CLUSTER_NAMESPACE - enrich : Deploy via helm3  using Ingress"
+   helm3 install $HELM_RELEASE . -f clinical_enrichment.yaml --set ascvd-from-fhir.ingress.enabled=true --set deid-prep.ingress.enabled=true --set term-services-prep.ingress.enabled=true --set nlp-insights.enabled=true --set nlp-insights.ingress.enabled=true --set nlp-insights.nlpservice.quickumls.endpoint=https://quickumls.wh-health-patterns.dev.watson-health.ibm.com/match --set nlp-insights.nlpservice.acd.endpoint=https://us-east.wh-acd.cloud.ibm.com/wh-acd/api --set nlp-insights.nlpservice.acd.apikey=$ACD_APIKEY --set nlp-insights.nlpservice.acd.flow=wh_acd.ibm_clinical_insights_v1.0_standard_flow --wait --timeout 6m0s
+elif $CLUSTER_NAMESPACE="clinical-ingestion" then
+   # deploy ingestion
+   echo "$CLUSTER_NAMESPACE - ingestion : Deploy via helm3  using Ingress"
+   date
+   helm3 install $HELM_RELEASE . -f clinical_ingestion.yaml --wait --timeout 6m0s
+   date
+fi
 
 # setup all the env vars for input to maven
 # FHIR Using INGRESS
@@ -100,6 +98,20 @@ export DEID_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/deid
 export DEID_PORT=
 echo "*************************************"
 echo DEID server: $DEID_IP$DEID_PORT
+echo "*************************************"
+
+# NIFI - using INGRESS
+export NIFI_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/
+export NIFI_PORT=
+echo "*************************************"
+echo NIFI server: $NIFI_IP$NIFI_PORT
+echo "*************************************"
+
+# EXPOSE KAFKA Service using INGRESS
+export EXP_KAFKA_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/expose-kafka
+export EXP_KAFKA_PORT=
+echo "*************************************"
+echo EXPOSE KAFKA Service: $EXP_KAFKA_IP$EXP_KAFKA_PORTT
 echo "*************************************"
 
 # DEID Prep - using INGRESS
@@ -130,64 +142,104 @@ echo "*************************************"
 echo NLP Insights server: $NLP_INSIGHTS_IP$NLP_INSIGHTS_PORT
 echo "*************************************"
 
-# Wait a bit for Nifi to come up
-# Need to change this to some polling of service status for more reliability 
-echo "*************************************"
-echo "* Waiting for 2 minutes             *"
-echo "*************************************"
-date
-sleep 120  
-date
-
-# KAFKA - using Load Balancer
-export KAFKA_IP=$(kubectl get svc --namespace $TEST_NAMESPACE $HELM_RELEASE-kafka-0-external -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
-export KAFKA_PORT=:$(kubectl get svc $HELM_RELEASE-kafka-0-external -o jsonpath='{.spec.ports[0].port}') 
-echo KAFKA server: $KAFKA_IP$KAFKA_PORT
+# Wait for deployment to be ready
+if $CLUSTER_NAMESPACE="clinical-enrichment" then 
+   echo "*************************************"
+   echo "* Waiting for 2 minutes             *"
+   echo "*************************************"
+   date
+   sleep 120  
+   date
+elif $CLUSTER_NAMESPACE="clinical-ingestion" then 
+   echo "*************************************"
+   echo "* Waiting for 5 minutes             *"
+   echo "*************************************"
+   date
+   sleep 300  
+   date
+fi
 
 echo "*************************************" 
 echo "* A Look At Everything              *"
 echo "*************************************"
 kubectl get all
 
-echo "****************************************************" 
-echo "* Goto the testcase folder in the repo             *"
-echo "****************************************************"
-cd /workspace/$TEST_NAMESPACE/health-patterns/clinical-enrichment/
-pwd
-ls
+if $CLUSTER_NAMESPACE="clinical-enrichment" then 
+   echo "****************************************************" 
+   echo "* Goto the testcase folder in the repo             *"
+   echo "****************************************************"
+   cd /workspace/$TEST_NAMESPACE/health-patterns/$CLUSTER_NAMESPACE/
+   pwd
+   ls
 
-echo "*************************************" 
-echo "* Build the testcases               *"
-echo "*************************************"
-mvn clean install -e -Dip.fhir=$FHIR_IP -Dport.fhir=$FHIR_PORT -Dip.fhir.deid=$FHIR_DEID_IP -Dport.fhir.deid=$FHIR_DEID_PORT -Dip.deid.prep=$DEID_PREP_IP -Dport.deid.prep=$DEID_PREP_PORT -Dip.term.prep=$TERM_PREP_IP -Dport.term.prep=$TERM_PREP_PORT -Dip.ascvd.from.fhir=$ASCVD_FROM_FHIR_IP -Dport.ascvd.from.fhir=$ASCVD_FROM_FHIR_PORT -Dip.nlp.insights=$NLP_INSIGHTS_IP -Dport.nlp.insights=$NLP_INSIGHTS_PORT -Dpw=$DEFAULT_PASSWORD
+   echo "*************************************" 
+   echo "* Build the testcases               *"
+   echo "*************************************"
+   mvn clean install -e -Dip.fhir=$FHIR_IP -Dport.fhir=$FHIR_PORT -Dip.fhir.deid=$FHIR_DEID_IP -Dport.fhir.deid=$FHIR_DEID_PORT -Dip.deid.prep=$DEID_PREP_IP -Dport.deid.prep=$DEID_PREP_PORT -Dip.term.prep=$TERM_PREP_IP -Dport.term.prep=$TERM_PREP_PORT -Dip.ascvd.from.fhir=$ASCVD_FROM_FHIR_IP -Dport.ascvd.from.fhir=$ASCVD_FROM_FHIR_PORT -Dip.nlp.insights=$NLP_INSIGHTS_IP -Dport.nlp.insights=$NLP_INSIGHTS_PORT -Dpw=$DEFAULT_PASSWORD
 
-echo "*************************************" 
-echo "* Properties File:                  *"
-echo "*************************************"
-cat src/test/resources/enrich-flow.properties
+   echo "*************************************" 
+   echo "* Properties File:                  *"
+   echo "*************************************"
+   cat src/test/resources/enrich-flow.properties
 
+   echo "*************************************" 
+   echo "* Execute the testcases             *"
+   echo "*************************************"
+   mvn -e -DskipTests=false -Dtest=EnrichmentInitTests test
+   mvn -e -DskipTests=false -Dtest=BasicEnrichmentTests test
+   mvn -e -DskipTests=false -Dtest=EnrichmentConfigTests test
+   mvn -e -DskipTests=false -Dtest=ASCVDEnrichmentTests test
 
-echo "*************************************" 
-echo "* Execute the testcases             *"
-echo "*************************************"
-mvn -e -DskipTests=false -Dtest=EnrichmentInitTests test
-mvn -e -DskipTests=false -Dtest=BasicEnrichmentTests test
-mvn -e -DskipTests=false -Dtest=EnrichmentConfigTests test
-mvn -e -DskipTests=false -Dtest=ASCVDEnrichmentTests test
+   # JUNIT execution reports available in the below folder
+   ls -lrt target/surefire-reports
+   cat target/surefire-reports/categories.EnrichmentInitTests.txt
+   cat target/surefire-reports/categories.BasicEnrichmentTests.txt
+   cat target/surefire-reports/categories.EnrichmentConfigTests.txt
+   cat target/surefire-reports/categories.ASCVDEnrichmentTests.txt
 
-# JUNIT execution reports available in the below folder
-ls -lrt target/surefire-reports
-cat target/surefire-reports/categories.EnrichmentInitTests.txt
-cat target/surefire-reports/categories.BasicEnrichmentTests.txt
-cat target/surefire-reports/categories.EnrichmentConfigTests.txt
-cat target/surefire-reports/categories.ASCVDEnrichmentTests.txt
+   echo "*************************************" 
+   echo "* Report Test Results to Insights   *"
+   echo "*************************************"
+   echo "<testsuites>" > /workspace/$CLUSTER_NAMESPACE/tests/smoketests.xml
+   cat target/surefire-reports/*.xml >> /workspace/$CLUSTER_NAMESPACE/tests/smoketests.xml
+   echo "</testsuites>" >> /workspace/$CLUSTER_NAMESPACE/tests/smoketests.xml
 
-echo "*************************************" 
-echo "* Report Test Results to Insights   *"
-echo "*************************************"
-echo "<testsuites>" > /workspace/clinical-enrichment/tests/smoketests.xml
-cat target/surefire-reports/*.xml >> /workspace/clinical-enrichment/tests/smoketests.xml
-echo "</testsuites>" >> /workspace/clinical-enrichment/tests/smoketests.xml
+elif $CLUSTER_NAMESPACE="clinical-ingestion" then
+   echo "****************************************************" 
+   echo "* Goto the testcase folder in the repo             *"
+   echo "****************************************************"
+   cd /workspace/$TEST_NAMESPACE/health-patterns/ingest/
+   pwd
+   ls
+   
+   echo "*************************************" 
+   echo "* Build the testcases               *"
+   echo "*************************************"
+   mvn clean install -e -Dip.fhir=$FHIR_IP -Dport.fhir=$FHIR_PORT -Dip.fhir.deid=$FHIR_DEID_IP -Dport.fhir.deid=$FHIR_DEID_PORT -Dip.nifi=$NIFI_IP -Dport.nifi=$NIFI_PORT -Dip.nifi.api=$NIFI_API_IP -Dport.nifi.api=$NIFI_API_PORT -Dip.kafka=$KAFKA_IP -Dport.kafka=$KAFKA_PORT -Dip.deid=$DEID_IP -Dport.deid=$DEID_PORT -Dip.expkafka=$EXP_KAFKA_IP -Dport.expkafka=$EXP_KAFKA_PORT -Dpw=$DEFAULT_PASSWORD
+
+   echo "*************************************" 
+   echo "* Initialize the testcases          *"
+   echo "*************************************"
+   mvn -e -DskipTests=false -Dtest=BasicClinicalIngestionInitTests test
+
+   echo "*************************************" 
+   echo "* Execute the testcases             *"
+   echo "*************************************"
+   mvn -e -DskipTests=false -Dtest=BasicClinicalIngestionFlowTests test 
+
+   # JUNIT execution reports available in the below folder
+   ls -lrt target/surefire-reports
+   cat target/surefire-reports/categories.BasicClinicalIngestionInitTests.txt
+   cat target/surefire-reports/categories.BasicClinicalIngestionFlowTests.txt
+
+   echo "*************************************" 
+   echo "* Report Test Results to Insights   *"
+   echo "*************************************"
+   echo "<testsuites>" > /workspace/ingest/tests/smoketests.xml
+   cat target/surefire-reports/*.xml >> /workspace/ingest/tests/smoketests.xml
+   echo "</testsuites>" >> /workspace/ingestion/tests/smoketests.xml
+fi
+
 
 # then clean up
 echo "*************************************"

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -5,18 +5,18 @@
 # Run the enrich/ingestion smoke tests and add test results to smoketests.xml for the Insights Quality Dashboard
 
 chmod +x ./tests/toolchain-envsetup.sh
-source ./tests/toolchain-envsetup.sh "-smoke"
+source ./tests/toolchain-envsetup.sh "smoke"
 
 echo " change to the correct directory"
 cd /workspace/$TEST_NAMESPACE/health-patterns/helm-charts/health-patterns
 
 # Execute the desired deployment
 echo $CLUSTER_NAMESPACE" : Deploy via helm3"
-if [ $CLUSER_NAMESPACE = "clinical-enrich" ] 
+if [ $CLUSTER_NAMESPACE = "clinical-enrich" ] 
 then
    # deploy enrich
    helm3 install $HELM_RELEASE . -f clinical_enrichment.yaml --set ascvd-from-fhir.ingress.enabled=true --set deid-prep.ingress.enabled=true --set term-services-prep.ingress.enabled=true --set nlp-insights.enabled=true --set nlp-insights.ingress.enabled=true --set nlp-insights.nlpservice.quickumls.endpoint=https://quickumls.wh-health-patterns.dev.watson-health.ibm.com/match --set nlp-insights.nlpservice.acd.endpoint=https://us-east.wh-acd.cloud.ibm.com/wh-acd/api --set nlp-insights.nlpservice.acd.apikey=$ACD_APIKEY --set nlp-insights.nlpservice.acd.flow=wh_acd.ibm_clinical_insights_v1.0_standard_flow --wait --timeout 6m0s
-elif [ $CLUSER_NAMESPACE = "clinical-ingestion" ] 
+elif [ $CLUSTER_NAMESPACE = "clinical-ingestion" ] 
 then
    # deploy ingestion
    helm3 install $HELM_RELEASE . -f clinical_ingestion.yaml --wait --timeout 6m0s
@@ -35,7 +35,7 @@ echo "* A Look At Everything              *"
 echo "*************************************"
 kubectl get all
 
-if [ $thisdeploy = $enrich ]  
+if [ $CLUSTER_NAMESPACE = "clinical-enrich" ]  
 then 
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"
@@ -63,7 +63,7 @@ then
    cat target/surefire-reports/categories.BasicEnrichmentTests.txt
    cat target/surefire-reports/categories.EnrichmentConfigTests.txt
    cat target/surefire-reports/categories.ASCVDEnrichmentTests.txt
-elif [ $thisdeploy = $ingest ] 
+elif [ $CLUSTER_NAMESPACE = "clinical-ingestion" ] 
 then
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -24,12 +24,14 @@ export TEST_NAMESPACE=$CLUSTER_NAMESPACE"-smoke"
 export INGRESS_SUBDOMAIN=wh-health-patterns.dev.watson-health.ibm.com
 #export JAVA_TOOL_OPTIONS=-Dhttps.protocols=TLSv1.3 
 
-cnd=$CLUSTER_NAMESPACE
+thisdeploy=$CLUSTER_NAMESPACE
+ingest="clinical-ingestion"
+enrich="clinical-enrich"
 
-if [cnd -eq "clinical-enrich"]
+if [$thisdeploy -eq $enrich]
 then
    export HELM_RELEASE=enrich
-elif [cnd -eq "clinical-ingestion"] 
+elif [$thisdeploy -eq $ingest] 
 then
    export HELM_RELEASE=ingestion
 fi
@@ -70,12 +72,12 @@ pwd
 sed -i -e "s/\&hostname replace-me/\&hostname $TEST_NAMESPACE.$INGRESS_SUBDOMAIN/g" values.yaml
 cat values.yaml | grep $TEST_NAMESPACE.$INGRESS_SUBDOMAIN
 
-if [cnd -eq "clinical-enrich"] 
+if [$thisdeploy -eq $enrich] 
 then
    # deploy enrich
    echo "$CLUSTER_NAMESPACE - enrich : Deploy via helm3  using Ingress"
    helm3 install $HELM_RELEASE . -f clinical_enrichment.yaml --set ascvd-from-fhir.ingress.enabled=true --set deid-prep.ingress.enabled=true --set term-services-prep.ingress.enabled=true --set nlp-insights.enabled=true --set nlp-insights.ingress.enabled=true --set nlp-insights.nlpservice.quickumls.endpoint=https://quickumls.wh-health-patterns.dev.watson-health.ibm.com/match --set nlp-insights.nlpservice.acd.endpoint=https://us-east.wh-acd.cloud.ibm.com/wh-acd/api --set nlp-insights.nlpservice.acd.apikey=$ACD_APIKEY --set nlp-insights.nlpservice.acd.flow=wh_acd.ibm_clinical_insights_v1.0_standard_flow --wait --timeout 6m0s
-elif [cnd -eq "clinical-ingestion"] 
+elif [$thisdeploy -eq $ingest] 
 then
    # deploy ingestion
    echo "$CLUSTER_NAMESPACE - ingestion : Deploy via helm3  using Ingress"
@@ -149,7 +151,7 @@ echo NLP Insights server: $NLP_INSIGHTS_IP$NLP_INSIGHTS_PORT
 echo "*************************************"
 
 # Wait for deployment to be ready
-if [cnd -eq "clinical-enrich"] 
+if [$thisdeploy -eq $enrich] 
 then 
    echo "*************************************"
    echo "* Waiting for 2 minutes             *"
@@ -157,7 +159,7 @@ then
    date
    sleep 120  
    date   
-elif [cnd -eq "clinical-ingestion"] 
+elif [$thisdeploy -eq $ingest] 
 then 
    echo "*************************************"
    echo "* Waiting for 5 minutes             *"
@@ -172,7 +174,7 @@ echo "* A Look At Everything              *"
 echo "*************************************"
 kubectl get all
 
-if [cnd -eq "clinical-enrich"] 
+if [$thisdeploy -eq $enrich] 
 then 
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"
@@ -212,7 +214,7 @@ then
    echo "<testsuites>" > /workspace/clinical-enrichment/tests/smoketests.xml
    cat target/surefire-reports/*.xml >> /workspace/clinical-enrichment/tests/smoketests.xml
    echo "</testsuites>" >> /workspace/clinical-enrichment/tests/smoketests.xml
-elif [cnd -eq "clinical-ingestion"] 
+elif [$thisdeploy -eq $ingest] 
 then
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -167,7 +167,7 @@ echo "* A Look At Everything              *"
 echo "*************************************"
 kubectl get all
 
-if [ $thisdeploy = $enrich ] 
+if [ $thisdeploy = $enrich ]  
 then 
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# Run the Avlearie Clinical Enrichment Deploy install per documented instructions
+# Run the Avlearie enrich/ingestion Deploy install per documented instructions (selection based on CLUSER_NAMESPACE from toolchain input
 #
-# Run the Clinical Enrichment smoke tests and add test results to smoketests.xml for the Insights Quality Dashboard
+# Run the enrich/ingestion smoke tests and add test results to smoketests.xml for the Insights Quality Dashboard
 
 echo "*************************************"
 echo "* Linux version                     *"
@@ -20,22 +20,25 @@ echo "*************************************"
 export DEFAULT_PASSWORD=integrati0n
 export JAVA_HOME=/usr/lib/jvm/java-1.8.0
 export TEST_NAMESPACE=$CLUSTER_NAMESPACE"-smoke"
-#This is for VPC cluster health-patterns-1
-export INGRESS_SUBDOMAIN=wh-health-patterns.dev.watson-health.ibm.com
-#export JAVA_TOOL_OPTIONS=-Dhttps.protocols=TLSv1.3 
 
+#This is for VPC cluster health-patterns-1
+export INGRESS_SUBDOMAIN=wh-health-patterns.dev.watson-health.ibm.com 
+
+# Setting these variables to make if-then-else logic readable/understandable
 thisdeploy=$CLUSTER_NAMESPACE
 ingest="clinical-ingestion"
 enrich="clinical-enrich"
 
+# deploymemt-specific variables/values
 if [ $thisdeploy = $enrich ]
 then
    export HELM_RELEASE=enrich
+   deploywait=120
 elif [ $thisdeploy = $ingest ] 
 then
    export HELM_RELEASE=ingestion
+   deploywait=300
 fi
-
 
 echo "*************************************"
 echo "* setup base directory for test     *"
@@ -72,15 +75,16 @@ pwd
 sed -i -e "s/\&hostname replace-me/\&hostname $TEST_NAMESPACE.$INGRESS_SUBDOMAIN/g" values.yaml
 cat values.yaml | grep $TEST_NAMESPACE.$INGRESS_SUBDOMAIN
 
+# Execute the desired deployment
 if [ $thisdeploy = $enrich ] 
 then
    # deploy enrich
-   echo "$CLUSTER_NAMESPACE - enrich : Deploy via helm3  using Ingress"
+   echo "$CLUSTER_NAMESPACE - enrich : Deploy via helm3"
    helm3 install $HELM_RELEASE . -f clinical_enrichment.yaml --set ascvd-from-fhir.ingress.enabled=true --set deid-prep.ingress.enabled=true --set term-services-prep.ingress.enabled=true --set nlp-insights.enabled=true --set nlp-insights.ingress.enabled=true --set nlp-insights.nlpservice.quickumls.endpoint=https://quickumls.wh-health-patterns.dev.watson-health.ibm.com/match --set nlp-insights.nlpservice.acd.endpoint=https://us-east.wh-acd.cloud.ibm.com/wh-acd/api --set nlp-insights.nlpservice.acd.apikey=$ACD_APIKEY --set nlp-insights.nlpservice.acd.flow=wh_acd.ibm_clinical_insights_v1.0_standard_flow --wait --timeout 6m0s
 elif [ $thisdeploy = $ingest ] 
 then
    # deploy ingestion
-   echo "$CLUSTER_NAMESPACE - ingestion : Deploy via helm3  using Ingress"
+   echo "$CLUSTER_NAMESPACE - ingestion : Deploy via helm3"
    date
    helm3 install $HELM_RELEASE . -f clinical_ingestion.yaml --wait --timeout 6m0s
    date
@@ -150,24 +154,13 @@ echo "*************************************"
 echo NLP Insights server: $NLP_INSIGHTS_IP$NLP_INSIGHTS_PORT
 echo "*************************************"
 
-# Wait for deployment to be ready
-if [ $thisdeploy = $enrich ] 
-then 
-   echo "*************************************"
-   echo "* Waiting for 2 minutes             *"
-   echo "*************************************"
-   date
-   sleep 120  
-   date   
-elif [ $thisdeploy = $ingest ] 
-then 
-   echo "*************************************"
-   echo "* Waiting for 5 minutes             *"
-   echo "*************************************"
-   date
-   sleep 300  
-   date
-fi
+
+echo "*************************************"
+echo "* Waiting for "$deploywait" seconds             *"
+echo "*************************************"
+date
+sleep $deploywait  
+date
 
 echo "*************************************" 
 echo "* A Look At Everything              *"
@@ -189,11 +182,6 @@ then
    mvn clean install -e -Dip.fhir=$FHIR_IP -Dport.fhir=$FHIR_PORT -Dip.fhir.deid=$FHIR_DEID_IP -Dport.fhir.deid=$FHIR_DEID_PORT -Dip.deid.prep=$DEID_PREP_IP -Dport.deid.prep=$DEID_PREP_PORT -Dip.term.prep=$TERM_PREP_IP -Dport.term.prep=$TERM_PREP_PORT -Dip.ascvd.from.fhir=$ASCVD_FROM_FHIR_IP -Dport.ascvd.from.fhir=$ASCVD_FROM_FHIR_PORT -Dip.nlp.insights=$NLP_INSIGHTS_IP -Dport.nlp.insights=$NLP_INSIGHTS_PORT -Dpw=$DEFAULT_PASSWORD
 
    echo "*************************************" 
-   echo "* Properties File:                  *"
-   echo "*************************************"
-   cat src/test/resources/enrich-flow.properties
-
-   echo "*************************************" 
    echo "* Execute the testcases             *"
    echo "*************************************"
    mvn -e -DskipTests=false -Dtest=EnrichmentInitTests test
@@ -207,13 +195,6 @@ then
    cat target/surefire-reports/categories.BasicEnrichmentTests.txt
    cat target/surefire-reports/categories.EnrichmentConfigTests.txt
    cat target/surefire-reports/categories.ASCVDEnrichmentTests.txt
-
-   echo "*************************************" 
-   echo "* Report Test Results to Insights   *"
-   echo "*************************************"
-   echo "<testsuites>" > /workspace/clinical-enrichment/tests/smoketests.xml
-   cat target/surefire-reports/*.xml >> /workspace/clinical-enrichment/tests/smoketests.xml
-   echo "</testsuites>" >> /workspace/clinical-enrichment/tests/smoketests.xml
 elif [ $thisdeploy = $ingest ] 
 then
    echo "****************************************************" 
@@ -229,7 +210,7 @@ then
    mvn clean install -e -Dip.fhir=$FHIR_IP -Dport.fhir=$FHIR_PORT -Dip.fhir.deid=$FHIR_DEID_IP -Dport.fhir.deid=$FHIR_DEID_PORT -Dip.nifi=$NIFI_IP -Dport.nifi=$NIFI_PORT -Dip.nifi.api=$NIFI_API_IP -Dport.nifi.api=$NIFI_API_PORT -Dip.kafka=$KAFKA_IP -Dport.kafka=$KAFKA_PORT -Dip.deid=$DEID_IP -Dport.deid=$DEID_PORT -Dip.expkafka=$EXP_KAFKA_IP -Dport.expkafka=$EXP_KAFKA_PORT -Dpw=$DEFAULT_PASSWORD
 
    echo "*************************************" 
-   echo "* Initialize the testcases          *"
+   echo "* Execute Initialize testcases      *"
    echo "*************************************"
    mvn -e -DskipTests=false -Dtest=BasicIngestionInitTests test
 
@@ -242,15 +223,14 @@ then
    ls -lrt target/surefire-reports
    cat target/surefire-reports/categories.BasicIngestionInitTests.txt
    cat target/surefire-reports/categories.BasicIngestionTests.txt
-
-   echo "*************************************" 
-   echo "* Report Test Results to Insights   *"
-   echo "*************************************"
-   echo "<testsuites>" > /workspace/clinical-enrichment/tests/smoketests.xml
-   cat target/surefire-reports/*.xml >> /workspace/clinical-enrichment/tests/smoketests.xml
-   echo "</testsuites>" >> /workspace/clinical-enrichment/smoketests.xml
 fi
 
+echo "*************************************" 
+echo "* Report Test Results to Insights   *"
+echo "*************************************"
+echo "<testsuites>" > /workspace/clinical-enrichment/tests/smoketests.xml
+cat target/surefire-reports/*.xml >> /workspace/clinical-enrichment/tests/smoketests.xml
+echo "</testsuites>" >> /workspace/clinical-enrichment/tests/smoketests.xml
 
 # then clean up
 echo "*************************************"
@@ -259,19 +239,3 @@ echo "*************************************"
 helm3 delete $HELM_RELEASE
 kubectl delete namespace $TEST_NAMESPACE
 
-
-# temp create a results file with "good" results while this script is developed
-#cd /workspace/clinical-ingestion/e2e-tests
-#output="<testcase classname=\"bash\" name=\"test1\" time=\"0\"/>"
-#currentTime=`date +"%Y-%m-%dT%T"`
-#header="<testsuite name=\"Smoke tests\" tests=\"0\" failures=\"0\" errors=\"0\" skipped=\"0\" timestamp=\"${currentTime}\" time=\"0\">"
-#footer="</testsuite>"
-
-#echo "Current Directory"
-#pwd
-
-#cat << EOF > smoketests.xml
-#$header
-#$output
-#$footer
-#EOF

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -24,7 +24,7 @@ export TEST_NAMESPACE=$CLUSTER_NAMESPACE"-smoke"
 export INGRESS_SUBDOMAIN=wh-health-patterns.dev.watson-health.ibm.com
 #export JAVA_TOOL_OPTIONS=-Dhttps.protocols=TLSv1.3 
 
-if $CLUSTER_NAMESPACE="clinical-enrichment" then
+if $CLUSTER_NAMESPACE="clinical-enrich" then
    export HELM_RELEASE=enrich
 elif $CLUSTER_NAMESPACE="clinical-ingestion" then
    export HELM_RELEASE=ingestion
@@ -66,7 +66,7 @@ pwd
 sed -i -e "s/\&hostname replace-me/\&hostname $TEST_NAMESPACE.$INGRESS_SUBDOMAIN/g" values.yaml
 cat values.yaml | grep $TEST_NAMESPACE.$INGRESS_SUBDOMAIN
 
-if $CLUSTER_NAMESPACE="clinical-enrichment" then
+if $CLUSTER_NAMESPACE="clinical-enrich" then
    # deploy enrich
    echo "$CLUSTER_NAMESPACE - enrich : Deploy via helm3  using Ingress"
    helm3 install $HELM_RELEASE . -f clinical_enrichment.yaml --set ascvd-from-fhir.ingress.enabled=true --set deid-prep.ingress.enabled=true --set term-services-prep.ingress.enabled=true --set nlp-insights.enabled=true --set nlp-insights.ingress.enabled=true --set nlp-insights.nlpservice.quickumls.endpoint=https://quickumls.wh-health-patterns.dev.watson-health.ibm.com/match --set nlp-insights.nlpservice.acd.endpoint=https://us-east.wh-acd.cloud.ibm.com/wh-acd/api --set nlp-insights.nlpservice.acd.apikey=$ACD_APIKEY --set nlp-insights.nlpservice.acd.flow=wh_acd.ibm_clinical_insights_v1.0_standard_flow --wait --timeout 6m0s
@@ -143,7 +143,7 @@ echo NLP Insights server: $NLP_INSIGHTS_IP$NLP_INSIGHTS_PORT
 echo "*************************************"
 
 # Wait for deployment to be ready
-if $CLUSTER_NAMESPACE="clinical-enrichment" then 
+if $CLUSTER_NAMESPACE="clinical-enrich" then 
    echo "*************************************"
    echo "* Waiting for 2 minutes             *"
    echo "*************************************"
@@ -164,11 +164,11 @@ echo "* A Look At Everything              *"
 echo "*************************************"
 kubectl get all
 
-if $CLUSTER_NAMESPACE="clinical-enrichment" then 
+if $CLUSTER_NAMESPACE="clinical-enrich" then 
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"
    echo "****************************************************"
-   cd /workspace/$TEST_NAMESPACE/health-patterns/$CLUSTER_NAMESPACE/
+   cd /workspace/$TEST_NAMESPACE/health-patterns/clinical-enrichment/
    pwd
    ls
 
@@ -200,9 +200,9 @@ if $CLUSTER_NAMESPACE="clinical-enrichment" then
    echo "*************************************" 
    echo "* Report Test Results to Insights   *"
    echo "*************************************"
-   echo "<testsuites>" > /workspace/$CLUSTER_NAMESPACE/tests/smoketests.xml
-   cat target/surefire-reports/*.xml >> /workspace/$CLUSTER_NAMESPACE/tests/smoketests.xml
-   echo "</testsuites>" >> /workspace/$CLUSTER_NAMESPACE/tests/smoketests.xml
+   echo "<testsuites>" > /workspace/clinical-enrichment/tests/smoketests.xml
+   cat target/surefire-reports/*.xml >> /workspace/clinical-enrichment/tests/smoketests.xml
+   echo "</testsuites>" >> /workspace/clinical-enrichment/tests/smoketests.xml
 
 elif $CLUSTER_NAMESPACE="clinical-ingestion" then
    echo "****************************************************" 

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -8,11 +8,11 @@
 chmod +x ./tests/toolchain-envsetup.sh
 source ./tests/toolchain-envsetup.sh "smoke"
 
-echo " change to the correct directory"
+echo " change to the correct deployment directory"
 cd /workspace/$TEST_NAMESPACE/health-patterns/helm-charts/health-patterns
 
 # Execute the desired deployment
-echo $CLUSTER_NAMESPACE" : Deploy via helm3"
+echo $TEST_NAMESPACE" : Deploy via helm3"
 if [ $CLUSTER_NAMESPACE = "clinical-enrich" ] 
 then
    # deploy enrich
@@ -25,7 +25,7 @@ fi
 
 
 echo "*************************************"
-echo "* Waiting for "$deploywait" seconds             *"
+echo "* Waiting for "$deploywait" seconds           *"
 echo "*************************************"
 date
 sleep $deploywait  

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -4,8 +4,8 @@
 #
 # Run the enrich/ingestion smoke tests and add test results to smoketests.xml for the Insights Quality Dashboard
  
-chmod +x toolchain_envsetup.sh
-source ./toolchain_envsetup.sh "-smoke"
+chmod +x ./tests/toolchain_envsetup.sh
+source ./tests/toolchain_envsetup.sh "-smoke"
 
 echo " change to the correct directory"
 cd /workspace/$TEST_NAMESPACE/health-patterns/helm-charts/health-patterns

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -26,10 +26,10 @@ export INGRESS_SUBDOMAIN=wh-health-patterns.dev.watson-health.ibm.com
 
 cnd=$CLUSTER_NAMESPACE
 
-if [$cnd -eq "clinical-enrich"]
+if [cnd -eq "clinical-enrich"]
 then
    export HELM_RELEASE=enrich
-elif [$cnd -eq "clinical-ingestion"] 
+elif [cnd -eq "clinical-ingestion"] 
 then
    export HELM_RELEASE=ingestion
 fi
@@ -70,12 +70,12 @@ pwd
 sed -i -e "s/\&hostname replace-me/\&hostname $TEST_NAMESPACE.$INGRESS_SUBDOMAIN/g" values.yaml
 cat values.yaml | grep $TEST_NAMESPACE.$INGRESS_SUBDOMAIN
 
-if [$cnd -eq "clinical-enrich"] 
+if [cnd -eq "clinical-enrich"] 
 then
    # deploy enrich
    echo "$CLUSTER_NAMESPACE - enrich : Deploy via helm3  using Ingress"
    helm3 install $HELM_RELEASE . -f clinical_enrichment.yaml --set ascvd-from-fhir.ingress.enabled=true --set deid-prep.ingress.enabled=true --set term-services-prep.ingress.enabled=true --set nlp-insights.enabled=true --set nlp-insights.ingress.enabled=true --set nlp-insights.nlpservice.quickumls.endpoint=https://quickumls.wh-health-patterns.dev.watson-health.ibm.com/match --set nlp-insights.nlpservice.acd.endpoint=https://us-east.wh-acd.cloud.ibm.com/wh-acd/api --set nlp-insights.nlpservice.acd.apikey=$ACD_APIKEY --set nlp-insights.nlpservice.acd.flow=wh_acd.ibm_clinical_insights_v1.0_standard_flow --wait --timeout 6m0s
-elif [$cnd -eq "clinical-ingestion"] 
+elif [cnd -eq "clinical-ingestion"] 
 then
    # deploy ingestion
    echo "$CLUSTER_NAMESPACE - ingestion : Deploy via helm3  using Ingress"
@@ -149,7 +149,7 @@ echo NLP Insights server: $NLP_INSIGHTS_IP$NLP_INSIGHTS_PORT
 echo "*************************************"
 
 # Wait for deployment to be ready
-if [$cnd -eq "clinical-enrich"] 
+if [cnd -eq "clinical-enrich"] 
 then 
    echo "*************************************"
    echo "* Waiting for 2 minutes             *"
@@ -157,7 +157,7 @@ then
    date
    sleep 120  
    date   
-elif [$cnd -eq "clinical-ingestion"] 
+elif [cnd -eq "clinical-ingestion"] 
 then 
    echo "*************************************"
    echo "* Waiting for 5 minutes             *"
@@ -172,7 +172,7 @@ echo "* A Look At Everything              *"
 echo "*************************************"
 kubectl get all
 
-if [$cnd -eq "clinical-enrich"] 
+if [cnd -eq "clinical-enrich"] 
 then 
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"
@@ -212,7 +212,7 @@ then
    echo "<testsuites>" > /workspace/clinical-enrichment/tests/smoketests.xml
    cat target/surefire-reports/*.xml >> /workspace/clinical-enrichment/tests/smoketests.xml
    echo "</testsuites>" >> /workspace/clinical-enrichment/tests/smoketests.xml
-elif [$cnd -eq "clinical-ingestion"] 
+elif [cnd -eq "clinical-ingestion"] 
 then
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -24,12 +24,14 @@ export TEST_NAMESPACE=$CLUSTER_NAMESPACE"-smoke"
 export INGRESS_SUBDOMAIN=wh-health-patterns.dev.watson-health.ibm.com
 #export JAVA_TOOL_OPTIONS=-Dhttps.protocols=TLSv1.3 
 
-if [$CLUSTER_NAMESPACE=="clinical-enrich"] 
+cns = $CLUSTER_NAMESPACE
+
+if [$cns=="clinical-enrich"]
 then
    export HELM_RELEASE=enrich
-elif [$CLUSTER_NAMESPACE="clinical-ingestion"] 
+elif [$cns=="clinical-ingestion"] 
 then
-   export HELM_RELEASE==ingestion
+   export HELM_RELEASE=ingestion
 fi
 
 
@@ -68,12 +70,12 @@ pwd
 sed -i -e "s/\&hostname replace-me/\&hostname $TEST_NAMESPACE.$INGRESS_SUBDOMAIN/g" values.yaml
 cat values.yaml | grep $TEST_NAMESPACE.$INGRESS_SUBDOMAIN
 
-if [$CLUSTER_NAMESPACE=="clinical-enrich"] 
+if [$cns=="clinical-enrich"] 
 then
    # deploy enrich
    echo "$CLUSTER_NAMESPACE - enrich : Deploy via helm3  using Ingress"
    helm3 install $HELM_RELEASE . -f clinical_enrichment.yaml --set ascvd-from-fhir.ingress.enabled=true --set deid-prep.ingress.enabled=true --set term-services-prep.ingress.enabled=true --set nlp-insights.enabled=true --set nlp-insights.ingress.enabled=true --set nlp-insights.nlpservice.quickumls.endpoint=https://quickumls.wh-health-patterns.dev.watson-health.ibm.com/match --set nlp-insights.nlpservice.acd.endpoint=https://us-east.wh-acd.cloud.ibm.com/wh-acd/api --set nlp-insights.nlpservice.acd.apikey=$ACD_APIKEY --set nlp-insights.nlpservice.acd.flow=wh_acd.ibm_clinical_insights_v1.0_standard_flow --wait --timeout 6m0s
-elif [$CLUSTER_NAMESPACE=="clinical-ingestion"] 
+elif [$cns=="clinical-ingestion"] 
 then
    # deploy ingestion
    echo "$CLUSTER_NAMESPACE - ingestion : Deploy via helm3  using Ingress"
@@ -147,7 +149,7 @@ echo NLP Insights server: $NLP_INSIGHTS_IP$NLP_INSIGHTS_PORT
 echo "*************************************"
 
 # Wait for deployment to be ready
-if [$CLUSTER_NAMESPACE=="clinical-enrich"] 
+if [$cns=="clinical-enrich"] 
 then 
    echo "*************************************"
    echo "* Waiting for 2 minutes             *"
@@ -155,7 +157,7 @@ then
    date
    sleep 120  
    date   
-elif [$CLUSTER_NAMESPACE=="clinical-ingestion"] 
+elif [$cns=="clinical-ingestion"] 
 then 
    echo "*************************************"
    echo "* Waiting for 5 minutes             *"
@@ -170,7 +172,7 @@ echo "* A Look At Everything              *"
 echo "*************************************"
 kubectl get all
 
-if [$CLUSTER_NAMESPACE=="clinical-enrich"] 
+if [$cns=="clinical-enrich"] 
 then 
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"
@@ -210,7 +212,7 @@ then
    echo "<testsuites>" > /workspace/clinical-enrichment/tests/smoketests.xml
    cat target/surefire-reports/*.xml >> /workspace/clinical-enrichment/tests/smoketests.xml
    echo "</testsuites>" >> /workspace/clinical-enrichment/tests/smoketests.xml
-elif [$CLUSTER_NAMESPACE=="clinical-ingestion"] 
+elif [$cns=="clinical-ingestion"] 
 then
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -26,7 +26,8 @@ export INGRESS_SUBDOMAIN=wh-health-patterns.dev.watson-health.ibm.com
 
 if [$CLUSTER_NAMESPACE = "clinical-enrich"] then
    export HELM_RELEASE=enrich
-elif [$CLUSTER_NAMESPACE = "clinical-ingestion"] then
+fi
+else if [$CLUSTER_NAMESPACE = "clinical-ingestion"] then
    export HELM_RELEASE=ingestion
 fi
 
@@ -70,7 +71,8 @@ if [$CLUSTER_NAMESPACE = "clinical-enrich"] then
    # deploy enrich
    echo "$CLUSTER_NAMESPACE - enrich : Deploy via helm3  using Ingress"
    helm3 install $HELM_RELEASE . -f clinical_enrichment.yaml --set ascvd-from-fhir.ingress.enabled=true --set deid-prep.ingress.enabled=true --set term-services-prep.ingress.enabled=true --set nlp-insights.enabled=true --set nlp-insights.ingress.enabled=true --set nlp-insights.nlpservice.quickumls.endpoint=https://quickumls.wh-health-patterns.dev.watson-health.ibm.com/match --set nlp-insights.nlpservice.acd.endpoint=https://us-east.wh-acd.cloud.ibm.com/wh-acd/api --set nlp-insights.nlpservice.acd.apikey=$ACD_APIKEY --set nlp-insights.nlpservice.acd.flow=wh_acd.ibm_clinical_insights_v1.0_standard_flow --wait --timeout 6m0s
-elif [$CLUSTER_NAMESPACE = "clinical-ingestion"] then
+fi
+else if [$CLUSTER_NAMESPACE = "clinical-ingestion"] then
    # deploy ingestion
    echo "$CLUSTER_NAMESPACE - ingestion : Deploy via helm3  using Ingress"
    date
@@ -150,7 +152,8 @@ if [$CLUSTER_NAMESPACE = "clinical-enrich"] then
    date
    sleep 120  
    date
-elif [$CLUSTER_NAMESPACE = "clinical-ingestion"] then 
+fi   
+else if [$CLUSTER_NAMESPACE = "clinical-ingestion"] then 
    echo "*************************************"
    echo "* Waiting for 5 minutes             *"
    echo "*************************************"
@@ -203,8 +206,8 @@ if [$CLUSTER_NAMESPACE = "clinical-enrich"] then
    echo "<testsuites>" > /workspace/clinical-enrichment/tests/smoketests.xml
    cat target/surefire-reports/*.xml >> /workspace/clinical-enrichment/tests/smoketests.xml
    echo "</testsuites>" >> /workspace/clinical-enrichment/tests/smoketests.xml
-
-elif [$CLUSTER_NAMESPACE = "clinical-ingestion"] then
+fi
+else if [$CLUSTER_NAMESPACE = "clinical-ingestion"] then
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"
    echo "****************************************************"

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -3,7 +3,8 @@
 # Run the Avlearie enrich/ingestion Deploy install per documented instructions (selection based on CLUSER_NAMESPACE from toolchain input
 #
 # Run the enrich/ingestion smoke tests and add test results to smoketests.xml for the Insights Quality Dashboard
- 
+pwd
+ls
 chmod +x ./tests/toolchain_envsetup.sh
 source ./tests/toolchain_envsetup.sh "-smoke"
 

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -24,12 +24,11 @@ export TEST_NAMESPACE=$CLUSTER_NAMESPACE"-smoke"
 export INGRESS_SUBDOMAIN=wh-health-patterns.dev.watson-health.ibm.com
 #export JAVA_TOOL_OPTIONS=-Dhttps.protocols=TLSv1.3 
 
-cns = $CLUSTER_NAMESPACE
 
-if [$cns -eq "clinical-enrich"]
+if [$CLUSTER_NAMESPACE -eq "clinical-enrich"]
 then
    export HELM_RELEASE=enrich
-elif [$cns -eq "clinical-ingestion"] 
+elif [$CLUSTER_NAMESPACE -eq "clinical-ingestion"] 
 then
    export HELM_RELEASE=ingestion
 fi
@@ -70,12 +69,12 @@ pwd
 sed -i -e "s/\&hostname replace-me/\&hostname $TEST_NAMESPACE.$INGRESS_SUBDOMAIN/g" values.yaml
 cat values.yaml | grep $TEST_NAMESPACE.$INGRESS_SUBDOMAIN
 
-if [$cns -eq "clinical-enrich"] 
+if [$CLUSTER_NAMESPACE -eq "clinical-enrich"] 
 then
    # deploy enrich
    echo "$CLUSTER_NAMESPACE - enrich : Deploy via helm3  using Ingress"
    helm3 install $HELM_RELEASE . -f clinical_enrichment.yaml --set ascvd-from-fhir.ingress.enabled=true --set deid-prep.ingress.enabled=true --set term-services-prep.ingress.enabled=true --set nlp-insights.enabled=true --set nlp-insights.ingress.enabled=true --set nlp-insights.nlpservice.quickumls.endpoint=https://quickumls.wh-health-patterns.dev.watson-health.ibm.com/match --set nlp-insights.nlpservice.acd.endpoint=https://us-east.wh-acd.cloud.ibm.com/wh-acd/api --set nlp-insights.nlpservice.acd.apikey=$ACD_APIKEY --set nlp-insights.nlpservice.acd.flow=wh_acd.ibm_clinical_insights_v1.0_standard_flow --wait --timeout 6m0s
-elif [$cns -eq "clinical-ingestion"] 
+elif [$CLUSTER_NAMESPACE -eq "clinical-ingestion"] 
 then
    # deploy ingestion
    echo "$CLUSTER_NAMESPACE - ingestion : Deploy via helm3  using Ingress"
@@ -149,7 +148,7 @@ echo NLP Insights server: $NLP_INSIGHTS_IP$NLP_INSIGHTS_PORT
 echo "*************************************"
 
 # Wait for deployment to be ready
-if [$cns -eq "clinical-enrich"] 
+if [$CLUSTER_NAMESPACE -eq "clinical-enrich"] 
 then 
    echo "*************************************"
    echo "* Waiting for 2 minutes             *"
@@ -157,7 +156,7 @@ then
    date
    sleep 120  
    date   
-elif [$cns -eq "clinical-ingestion"] 
+elif [$CLUSTER_NAMESPACE -eq "clinical-ingestion"] 
 then 
    echo "*************************************"
    echo "* Waiting for 5 minutes             *"
@@ -172,7 +171,7 @@ echo "* A Look At Everything              *"
 echo "*************************************"
 kubectl get all
 
-if [$cns -eq "clinical-enrich"] 
+if [$CLUSTER_NAMESPACE -eq "clinical-enrich"] 
 then 
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"
@@ -212,7 +211,7 @@ then
    echo "<testsuites>" > /workspace/clinical-enrichment/tests/smoketests.xml
    cat target/surefire-reports/*.xml >> /workspace/clinical-enrichment/tests/smoketests.xml
    echo "</testsuites>" >> /workspace/clinical-enrichment/tests/smoketests.xml
-elif [$cns -eq "clinical-ingestion"] 
+elif [$CLUSTER_NAMESPACE -eq "clinical-ingestion"] 
 then
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -24,12 +24,10 @@ export TEST_NAMESPACE=$CLUSTER_NAMESPACE"-smoke"
 export INGRESS_SUBDOMAIN=wh-health-patterns.dev.watson-health.ibm.com
 #export JAVA_TOOL_OPTIONS=-Dhttps.protocols=TLSv1.3 
 
-echo "Cluster Namespace passed in is '"$CLUSTER_NAMESPACE"'"
-
-if [$CLUSTER_NAMESPACE = "clinical-enrich"] 
+if [$CLUSTER_NAMESPACE="clinical-enrich"] 
 then
    export HELM_RELEASE=enrich
-elif [$CLUSTER_NAMESPACE = "clinical-ingestion"] 
+elif [$CLUSTER_NAMESPACE="clinical-ingestion"] 
 then
    export HELM_RELEASE=ingestion
 fi
@@ -70,12 +68,12 @@ pwd
 sed -i -e "s/\&hostname replace-me/\&hostname $TEST_NAMESPACE.$INGRESS_SUBDOMAIN/g" values.yaml
 cat values.yaml | grep $TEST_NAMESPACE.$INGRESS_SUBDOMAIN
 
-if [$CLUSTER_NAMESPACE = "clinical-enrich"] 
+if [$CLUSTER_NAMESPACE="clinical-enrich"] 
 then
    # deploy enrich
    echo "$CLUSTER_NAMESPACE - enrich : Deploy via helm3  using Ingress"
    helm3 install $HELM_RELEASE . -f clinical_enrichment.yaml --set ascvd-from-fhir.ingress.enabled=true --set deid-prep.ingress.enabled=true --set term-services-prep.ingress.enabled=true --set nlp-insights.enabled=true --set nlp-insights.ingress.enabled=true --set nlp-insights.nlpservice.quickumls.endpoint=https://quickumls.wh-health-patterns.dev.watson-health.ibm.com/match --set nlp-insights.nlpservice.acd.endpoint=https://us-east.wh-acd.cloud.ibm.com/wh-acd/api --set nlp-insights.nlpservice.acd.apikey=$ACD_APIKEY --set nlp-insights.nlpservice.acd.flow=wh_acd.ibm_clinical_insights_v1.0_standard_flow --wait --timeout 6m0s
-elif [$CLUSTER_NAMESPACE = "clinical-ingestion"] 
+elif [$CLUSTER_NAMESPACE="clinical-ingestion"] 
 then
    # deploy ingestion
    echo "$CLUSTER_NAMESPACE - ingestion : Deploy via helm3  using Ingress"
@@ -149,7 +147,7 @@ echo NLP Insights server: $NLP_INSIGHTS_IP$NLP_INSIGHTS_PORT
 echo "*************************************"
 
 # Wait for deployment to be ready
-if [$CLUSTER_NAMESPACE = "clinical-enrich"] 
+if [$CLUSTER_NAMESPACE="clinical-enrich"] 
 then 
    echo "*************************************"
    echo "* Waiting for 2 minutes             *"
@@ -157,7 +155,7 @@ then
    date
    sleep 120  
    date   
-elif [$CLUSTER_NAMESPACE = "clinical-ingestion"] 
+elif [$CLUSTER_NAMESPACE="clinical-ingestion"] 
 then 
    echo "*************************************"
    echo "* Waiting for 5 minutes             *"
@@ -172,7 +170,7 @@ echo "* A Look At Everything              *"
 echo "*************************************"
 kubectl get all
 
-if [$CLUSTER_NAMESPACE = "clinical-enrich"] 
+if [$CLUSTER_NAMESPACE="clinical-enrich"] 
 then 
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"
@@ -212,7 +210,7 @@ then
    echo "<testsuites>" > /workspace/clinical-enrichment/tests/smoketests.xml
    cat target/surefire-reports/*.xml >> /workspace/clinical-enrichment/tests/smoketests.xml
    echo "</testsuites>" >> /workspace/clinical-enrichment/tests/smoketests.xml
-elif [$CLUSTER_NAMESPACE = "clinical-ingestion"] 
+elif [$CLUSTER_NAMESPACE="clinical-ingestion"] 
 then
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -179,7 +179,7 @@ then
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"
    echo "****************************************************"
-   cd /workspace/clinical-enrichment/health-patterns/clinical-enrichment/
+   cd /workspace/$TEST_NAMESPACE/health-patterns/clinical-enrichment/
    pwd
    ls
 
@@ -219,7 +219,7 @@ then
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"
    echo "****************************************************"
-   cd /workspace/ingest/health-patterns/ingest/
+   cd /workspace/$TEST_NAMESPACE/health-patterns/ingest/
    pwd
    ls
    
@@ -246,9 +246,9 @@ then
    echo "*************************************" 
    echo "* Report Test Results to Insights   *"
    echo "*************************************"
-   echo "<testsuites>" > /workspace/ingest/tests/smoketests.xml
-   cat target/surefire-reports/*.xml >> /workspace/ingest/tests/smoketests.xml
-   echo "</testsuites>" >> /workspace/ingest/tests/smoketests.xml
+   echo "<testsuites>" > /workspace/clinical-enrichment/tests/smoketests.xml
+   cat target/surefire-reports/*.xml >> /workspace/clinical-enrichment/tests/smoketests.xml
+   echo "</testsuites>" >> /workspace/ingest/clinical-enrichment/smoketests.xml
 fi
 
 

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -24,9 +24,9 @@ export TEST_NAMESPACE=$CLUSTER_NAMESPACE"-smoke"
 export INGRESS_SUBDOMAIN=wh-health-patterns.dev.watson-health.ibm.com
 #export JAVA_TOOL_OPTIONS=-Dhttps.protocols=TLSv1.3 
 
-if $CLUSTER_NAMESPACE="clinical-enrich" then
+if [$CLUSTER_NAMESPACE = "clinical-enrich"] then
    export HELM_RELEASE=enrich
-elif $CLUSTER_NAMESPACE="clinical-ingestion" then
+elif[$CLUSTER_NAMESPACE = "clinical-ingestion"] then
    export HELM_RELEASE=ingestion
 fi
 
@@ -66,11 +66,11 @@ pwd
 sed -i -e "s/\&hostname replace-me/\&hostname $TEST_NAMESPACE.$INGRESS_SUBDOMAIN/g" values.yaml
 cat values.yaml | grep $TEST_NAMESPACE.$INGRESS_SUBDOMAIN
 
-if $CLUSTER_NAMESPACE="clinical-enrich" then
+if [$CLUSTER_NAMESPACE = "clinical-enrich"] then
    # deploy enrich
    echo "$CLUSTER_NAMESPACE - enrich : Deploy via helm3  using Ingress"
    helm3 install $HELM_RELEASE . -f clinical_enrichment.yaml --set ascvd-from-fhir.ingress.enabled=true --set deid-prep.ingress.enabled=true --set term-services-prep.ingress.enabled=true --set nlp-insights.enabled=true --set nlp-insights.ingress.enabled=true --set nlp-insights.nlpservice.quickumls.endpoint=https://quickumls.wh-health-patterns.dev.watson-health.ibm.com/match --set nlp-insights.nlpservice.acd.endpoint=https://us-east.wh-acd.cloud.ibm.com/wh-acd/api --set nlp-insights.nlpservice.acd.apikey=$ACD_APIKEY --set nlp-insights.nlpservice.acd.flow=wh_acd.ibm_clinical_insights_v1.0_standard_flow --wait --timeout 6m0s
-elif $CLUSTER_NAMESPACE="clinical-ingestion" then
+elif [$CLUSTER_NAMESPACE = "clinical-ingestion"] then
    # deploy ingestion
    echo "$CLUSTER_NAMESPACE - ingestion : Deploy via helm3  using Ingress"
    date
@@ -143,14 +143,14 @@ echo NLP Insights server: $NLP_INSIGHTS_IP$NLP_INSIGHTS_PORT
 echo "*************************************"
 
 # Wait for deployment to be ready
-if $CLUSTER_NAMESPACE="clinical-enrich" then 
+if [$CLUSTER_NAMESPACE = "clinical-enrich"] then 
    echo "*************************************"
    echo "* Waiting for 2 minutes             *"
    echo "*************************************"
    date
    sleep 120  
    date
-elif $CLUSTER_NAMESPACE="clinical-ingestion" then 
+elif [$CLUSTER_NAMESPACE = "clinical-ingestion"] then 
    echo "*************************************"
    echo "* Waiting for 5 minutes             *"
    echo "*************************************"
@@ -164,7 +164,7 @@ echo "* A Look At Everything              *"
 echo "*************************************"
 kubectl get all
 
-if $CLUSTER_NAMESPACE="clinical-enrich" then 
+if [$CLUSTER_NAMESPACE = "clinical-enrich"] then 
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"
    echo "****************************************************"
@@ -204,7 +204,7 @@ if $CLUSTER_NAMESPACE="clinical-enrich" then
    cat target/surefire-reports/*.xml >> /workspace/clinical-enrichment/tests/smoketests.xml
    echo "</testsuites>" >> /workspace/clinical-enrichment/tests/smoketests.xml
 
-elif $CLUSTER_NAMESPACE="clinical-ingestion" then
+elif [$CLUSTER_NAMESPACE = "clinical-ingestion"] then
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"
    echo "****************************************************"

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -28,10 +28,10 @@ thisdeploy=$CLUSTER_NAMESPACE
 ingest="clinical-ingestion"
 enrich="clinical-enrich"
 
-if [$thisdeploy -eq $enrich]
+if [$thisdeploy = $enrich]
 then
    export HELM_RELEASE=enrich
-elif [$thisdeploy -eq $ingest] 
+elif [$thisdeploy = $ingest] 
 then
    export HELM_RELEASE=ingestion
 fi
@@ -72,12 +72,12 @@ pwd
 sed -i -e "s/\&hostname replace-me/\&hostname $TEST_NAMESPACE.$INGRESS_SUBDOMAIN/g" values.yaml
 cat values.yaml | grep $TEST_NAMESPACE.$INGRESS_SUBDOMAIN
 
-if [$thisdeploy -eq $enrich] 
+if [$thisdeploy = $enrich] 
 then
    # deploy enrich
    echo "$CLUSTER_NAMESPACE - enrich : Deploy via helm3  using Ingress"
    helm3 install $HELM_RELEASE . -f clinical_enrichment.yaml --set ascvd-from-fhir.ingress.enabled=true --set deid-prep.ingress.enabled=true --set term-services-prep.ingress.enabled=true --set nlp-insights.enabled=true --set nlp-insights.ingress.enabled=true --set nlp-insights.nlpservice.quickumls.endpoint=https://quickumls.wh-health-patterns.dev.watson-health.ibm.com/match --set nlp-insights.nlpservice.acd.endpoint=https://us-east.wh-acd.cloud.ibm.com/wh-acd/api --set nlp-insights.nlpservice.acd.apikey=$ACD_APIKEY --set nlp-insights.nlpservice.acd.flow=wh_acd.ibm_clinical_insights_v1.0_standard_flow --wait --timeout 6m0s
-elif [$thisdeploy -eq $ingest] 
+elif [$thisdeploy = $ingest] 
 then
    # deploy ingestion
    echo "$CLUSTER_NAMESPACE - ingestion : Deploy via helm3  using Ingress"
@@ -151,7 +151,7 @@ echo NLP Insights server: $NLP_INSIGHTS_IP$NLP_INSIGHTS_PORT
 echo "*************************************"
 
 # Wait for deployment to be ready
-if [$thisdeploy -eq $enrich] 
+if [$thisdeploy = $enrich] 
 then 
    echo "*************************************"
    echo "* Waiting for 2 minutes             *"
@@ -159,7 +159,7 @@ then
    date
    sleep 120  
    date   
-elif [$thisdeploy -eq $ingest] 
+elif [$thisdeploy = $ingest] 
 then 
    echo "*************************************"
    echo "* Waiting for 5 minutes             *"
@@ -174,7 +174,7 @@ echo "* A Look At Everything              *"
 echo "*************************************"
 kubectl get all
 
-if [$thisdeploy -eq $enrich] 
+if [$thisdeploy = $enrich] 
 then 
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"
@@ -214,7 +214,7 @@ then
    echo "<testsuites>" > /workspace/clinical-enrichment/tests/smoketests.xml
    cat target/surefire-reports/*.xml >> /workspace/clinical-enrichment/tests/smoketests.xml
    echo "</testsuites>" >> /workspace/clinical-enrichment/tests/smoketests.xml
-elif [$thisdeploy -eq $ingest] 
+elif [$thisdeploy = $ingest] 
 then
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -24,6 +24,8 @@ export TEST_NAMESPACE=$CLUSTER_NAMESPACE"-smoke"
 export INGRESS_SUBDOMAIN=wh-health-patterns.dev.watson-health.ibm.com
 #export JAVA_TOOL_OPTIONS=-Dhttps.protocols=TLSv1.3 
 
+echo "Cluster Namespace passed in is '"$CLUSTER_NAMESPACE"'"
+
 if [$CLUSTER_NAMESPACE = "clinical-enrich"] 
 then
    export HELM_RELEASE=enrich

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -24,12 +24,12 @@ export TEST_NAMESPACE=$CLUSTER_NAMESPACE"-smoke"
 export INGRESS_SUBDOMAIN=wh-health-patterns.dev.watson-health.ibm.com
 #export JAVA_TOOL_OPTIONS=-Dhttps.protocols=TLSv1.3 
 
-if [$CLUSTER_NAMESPACE="clinical-enrich"] 
+if [$CLUSTER_NAMESPACE=="clinical-enrich"] 
 then
    export HELM_RELEASE=enrich
 elif [$CLUSTER_NAMESPACE="clinical-ingestion"] 
 then
-   export HELM_RELEASE=ingestion
+   export HELM_RELEASE==ingestion
 fi
 
 
@@ -68,12 +68,12 @@ pwd
 sed -i -e "s/\&hostname replace-me/\&hostname $TEST_NAMESPACE.$INGRESS_SUBDOMAIN/g" values.yaml
 cat values.yaml | grep $TEST_NAMESPACE.$INGRESS_SUBDOMAIN
 
-if [$CLUSTER_NAMESPACE="clinical-enrich"] 
+if [$CLUSTER_NAMESPACE=="clinical-enrich"] 
 then
    # deploy enrich
    echo "$CLUSTER_NAMESPACE - enrich : Deploy via helm3  using Ingress"
    helm3 install $HELM_RELEASE . -f clinical_enrichment.yaml --set ascvd-from-fhir.ingress.enabled=true --set deid-prep.ingress.enabled=true --set term-services-prep.ingress.enabled=true --set nlp-insights.enabled=true --set nlp-insights.ingress.enabled=true --set nlp-insights.nlpservice.quickumls.endpoint=https://quickumls.wh-health-patterns.dev.watson-health.ibm.com/match --set nlp-insights.nlpservice.acd.endpoint=https://us-east.wh-acd.cloud.ibm.com/wh-acd/api --set nlp-insights.nlpservice.acd.apikey=$ACD_APIKEY --set nlp-insights.nlpservice.acd.flow=wh_acd.ibm_clinical_insights_v1.0_standard_flow --wait --timeout 6m0s
-elif [$CLUSTER_NAMESPACE="clinical-ingestion"] 
+elif [$CLUSTER_NAMESPACE=="clinical-ingestion"] 
 then
    # deploy ingestion
    echo "$CLUSTER_NAMESPACE - ingestion : Deploy via helm3  using Ingress"
@@ -147,7 +147,7 @@ echo NLP Insights server: $NLP_INSIGHTS_IP$NLP_INSIGHTS_PORT
 echo "*************************************"
 
 # Wait for deployment to be ready
-if [$CLUSTER_NAMESPACE="clinical-enrich"] 
+if [$CLUSTER_NAMESPACE=="clinical-enrich"] 
 then 
    echo "*************************************"
    echo "* Waiting for 2 minutes             *"
@@ -155,7 +155,7 @@ then
    date
    sleep 120  
    date   
-elif [$CLUSTER_NAMESPACE="clinical-ingestion"] 
+elif [$CLUSTER_NAMESPACE=="clinical-ingestion"] 
 then 
    echo "*************************************"
    echo "* Waiting for 5 minutes             *"
@@ -170,7 +170,7 @@ echo "* A Look At Everything              *"
 echo "*************************************"
 kubectl get all
 
-if [$CLUSTER_NAMESPACE="clinical-enrich"] 
+if [$CLUSTER_NAMESPACE=="clinical-enrich"] 
 then 
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"
@@ -210,7 +210,7 @@ then
    echo "<testsuites>" > /workspace/clinical-enrichment/tests/smoketests.xml
    cat target/surefire-reports/*.xml >> /workspace/clinical-enrichment/tests/smoketests.xml
    echo "</testsuites>" >> /workspace/clinical-enrichment/tests/smoketests.xml
-elif [$CLUSTER_NAMESPACE="clinical-ingestion"] 
+elif [$CLUSTER_NAMESPACE=="clinical-ingestion"] 
 then
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -179,7 +179,7 @@ then
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"
    echo "****************************************************"
-   cd /workspace/$TEST_NAMESPACE/health-patterns/clinical-enrichment/
+   cd /workspace/clinical-enrichment/health-patterns/clinical-enrichment/
    pwd
    ls
 
@@ -219,7 +219,7 @@ then
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"
    echo "****************************************************"
-   cd /workspace/$TEST_NAMESPACE/health-patterns/ingest/
+   cd /workspace/ingest/health-patterns/ingest/
    pwd
    ls
    
@@ -248,7 +248,7 @@ then
    echo "*************************************"
    echo "<testsuites>" > /workspace/ingest/tests/smoketests.xml
    cat target/surefire-reports/*.xml >> /workspace/ingest/tests/smoketests.xml
-   echo "</testsuites>" >> /workspace/ingestion/tests/smoketests.xml
+   echo "</testsuites>" >> /workspace/ingest/tests/smoketests.xml
 fi
 
 

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -231,17 +231,17 @@ then
    echo "*************************************" 
    echo "* Initialize the testcases          *"
    echo "*************************************"
-   mvn -e -DskipTests=false -Dtest=BasicClinicalIngestionInitTests test
+   mvn -e -DskipTests=false -Dtest=BasicIngestionInitTests test
 
    echo "*************************************" 
    echo "* Execute the testcases             *"
    echo "*************************************"
-   mvn -e -DskipTests=false -Dtest=BasicClinicalIngestionFlowTests test 
+   mvn -e -DskipTests=false -Dtest=BasicIngestionTests test 
 
    # JUNIT execution reports available in the below folder
    ls -lrt target/surefire-reports
-   cat target/surefire-reports/categories.BasicClinicalIngestionInitTests.txt
-   cat target/surefire-reports/categories.BasicClinicalIngestionFlowTests.txt
+   cat target/surefire-reports/categories.BasicIngestionInitTests.txt
+   cat target/surefire-reports/categories.BasicIngestionTests.txt
 
    echo "*************************************" 
    echo "* Report Test Results to Insights   *"

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -24,10 +24,11 @@ export TEST_NAMESPACE=$CLUSTER_NAMESPACE"-smoke"
 export INGRESS_SUBDOMAIN=wh-health-patterns.dev.watson-health.ibm.com
 #export JAVA_TOOL_OPTIONS=-Dhttps.protocols=TLSv1.3 
 
-if [$CLUSTER_NAMESPACE = "clinical-enrich"] then
+if [$CLUSTER_NAMESPACE = "clinical-enrich"] 
+then
    export HELM_RELEASE=enrich
-fi
-else if [$CLUSTER_NAMESPACE = "clinical-ingestion"] then
+elif [$CLUSTER_NAMESPACE = "clinical-ingestion"] 
+then
    export HELM_RELEASE=ingestion
 fi
 
@@ -67,12 +68,13 @@ pwd
 sed -i -e "s/\&hostname replace-me/\&hostname $TEST_NAMESPACE.$INGRESS_SUBDOMAIN/g" values.yaml
 cat values.yaml | grep $TEST_NAMESPACE.$INGRESS_SUBDOMAIN
 
-if [$CLUSTER_NAMESPACE = "clinical-enrich"] then
+if [$CLUSTER_NAMESPACE = "clinical-enrich"] 
+then
    # deploy enrich
    echo "$CLUSTER_NAMESPACE - enrich : Deploy via helm3  using Ingress"
    helm3 install $HELM_RELEASE . -f clinical_enrichment.yaml --set ascvd-from-fhir.ingress.enabled=true --set deid-prep.ingress.enabled=true --set term-services-prep.ingress.enabled=true --set nlp-insights.enabled=true --set nlp-insights.ingress.enabled=true --set nlp-insights.nlpservice.quickumls.endpoint=https://quickumls.wh-health-patterns.dev.watson-health.ibm.com/match --set nlp-insights.nlpservice.acd.endpoint=https://us-east.wh-acd.cloud.ibm.com/wh-acd/api --set nlp-insights.nlpservice.acd.apikey=$ACD_APIKEY --set nlp-insights.nlpservice.acd.flow=wh_acd.ibm_clinical_insights_v1.0_standard_flow --wait --timeout 6m0s
-fi
-else if [$CLUSTER_NAMESPACE = "clinical-ingestion"] then
+elif [$CLUSTER_NAMESPACE = "clinical-ingestion"] 
+then
    # deploy ingestion
    echo "$CLUSTER_NAMESPACE - ingestion : Deploy via helm3  using Ingress"
    date
@@ -145,15 +147,16 @@ echo NLP Insights server: $NLP_INSIGHTS_IP$NLP_INSIGHTS_PORT
 echo "*************************************"
 
 # Wait for deployment to be ready
-if [$CLUSTER_NAMESPACE = "clinical-enrich"] then 
+if [$CLUSTER_NAMESPACE = "clinical-enrich"] 
+then 
    echo "*************************************"
    echo "* Waiting for 2 minutes             *"
    echo "*************************************"
    date
    sleep 120  
-   date
-fi   
-else if [$CLUSTER_NAMESPACE = "clinical-ingestion"] then 
+   date   
+elif [$CLUSTER_NAMESPACE = "clinical-ingestion"] 
+then 
    echo "*************************************"
    echo "* Waiting for 5 minutes             *"
    echo "*************************************"
@@ -167,7 +170,8 @@ echo "* A Look At Everything              *"
 echo "*************************************"
 kubectl get all
 
-if [$CLUSTER_NAMESPACE = "clinical-enrich"] then 
+if [$CLUSTER_NAMESPACE = "clinical-enrich"] 
+then 
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"
    echo "****************************************************"
@@ -206,8 +210,8 @@ if [$CLUSTER_NAMESPACE = "clinical-enrich"] then
    echo "<testsuites>" > /workspace/clinical-enrichment/tests/smoketests.xml
    cat target/surefire-reports/*.xml >> /workspace/clinical-enrichment/tests/smoketests.xml
    echo "</testsuites>" >> /workspace/clinical-enrichment/tests/smoketests.xml
-fi
-else if [$CLUSTER_NAMESPACE = "clinical-ingestion"] then
+elif [$CLUSTER_NAMESPACE = "clinical-ingestion"] 
+then
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"
    echo "****************************************************"

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -26,7 +26,7 @@ export INGRESS_SUBDOMAIN=wh-health-patterns.dev.watson-health.ibm.com
 
 if [$CLUSTER_NAMESPACE = "clinical-enrich"] then
    export HELM_RELEASE=enrich
-elif[$CLUSTER_NAMESPACE = "clinical-ingestion"] then
+elif [$CLUSTER_NAMESPACE = "clinical-ingestion"] then
    export HELM_RELEASE=ingestion
 fi
 

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -3,156 +3,24 @@
 # Run the Avlearie enrich/ingestion Deploy install per documented instructions (selection based on CLUSER_NAMESPACE from toolchain input
 #
 # Run the enrich/ingestion smoke tests and add test results to smoketests.xml for the Insights Quality Dashboard
-
-echo "*************************************"
-echo "* Linux version                     *"
-echo "*************************************"
-cat /etc/redhat-release
-
-echo "*************************************"
-echo "* Current Directory                 *"
-echo "*************************************"
-pwd
-
-echo "*************************************"
-echo "* Set Test env variables            *"
-echo "*************************************"
-export DEFAULT_PASSWORD=integrati0n
-export JAVA_HOME=/usr/lib/jvm/java-1.8.0
-export TEST_NAMESPACE=$CLUSTER_NAMESPACE"-smoke"
-
-#This is for VPC cluster health-patterns-1
-export INGRESS_SUBDOMAIN=wh-health-patterns.dev.watson-health.ibm.com 
-
-# Setting these variables to make if-then-else logic readable/understandable
-thisdeploy=$CLUSTER_NAMESPACE
-ingest="clinical-ingestion"
-enrich="clinical-enrich"
-
-# deploymemt-specific variables/values
-if [ $thisdeploy = $enrich ]
-then
-   export HELM_RELEASE=enrich
-   deploywait=120
-elif [ $thisdeploy = $ingest ] 
-then
-   export HELM_RELEASE=ingestion
-   deploywait=300
-fi
-
-echo "*************************************"
-echo "* setup base directory for test     *"
-echo "*************************************"
-cd /workspace
-mkdir $TEST_NAMESPACE
-cd $TEST_NAMESPACE
-
-echo "*************************************"
-echo "* create namespace and set to it    *"
-echo "*************************************"
-kubectl create namespace $TEST_NAMESPACE
-
-echo " Set namespace to $TEST_NAMESPACE"
-kubectl config set-context --current --namespace=$TEST_NAMESPACE
-
-echo "*************************************"
-echo "* Clinical Ingestion Deploy         *"
-echo "*************************************"
-
-echo " clone clinical ingestion git repo using "$GIT_BRANCH " branch"
-git clone --branch $GIT_BRANCH https://github.com/Alvearie/health-patterns.git
+ 
+chmod +x toolchain_envsetup.sh
+source ./toolchain_envsetup.sh "-smoke"
 
 echo " change to the correct directory"
-cd health-patterns/helm-charts/health-patterns
-
-echo " helm dependency update"
-helm3 dependency update
-
-echo " Current Directory:"
-pwd
-
-# Add hostname to values.yaml
-sed -i -e "s/\&hostname replace-me/\&hostname $TEST_NAMESPACE.$INGRESS_SUBDOMAIN/g" values.yaml
-cat values.yaml | grep $TEST_NAMESPACE.$INGRESS_SUBDOMAIN
+cd /workspace/$TEST_NAMESPACE/health-patterns/helm-charts/health-patterns
 
 # Execute the desired deployment
-if [ $thisdeploy = $enrich ] 
+echo $CLUSTER_NAMESPACE" : Deploy via helm3"
+if [ $CLUSER_NAMESPACE = "clinical-enrich" ] 
 then
    # deploy enrich
-   echo "$CLUSTER_NAMESPACE - enrich : Deploy via helm3"
    helm3 install $HELM_RELEASE . -f clinical_enrichment.yaml --set ascvd-from-fhir.ingress.enabled=true --set deid-prep.ingress.enabled=true --set term-services-prep.ingress.enabled=true --set nlp-insights.enabled=true --set nlp-insights.ingress.enabled=true --set nlp-insights.nlpservice.quickumls.endpoint=https://quickumls.wh-health-patterns.dev.watson-health.ibm.com/match --set nlp-insights.nlpservice.acd.endpoint=https://us-east.wh-acd.cloud.ibm.com/wh-acd/api --set nlp-insights.nlpservice.acd.apikey=$ACD_APIKEY --set nlp-insights.nlpservice.acd.flow=wh_acd.ibm_clinical_insights_v1.0_standard_flow --wait --timeout 6m0s
-elif [ $thisdeploy = $ingest ] 
+elif [ $CLUSER_NAMESPACE = "clinical-ingestion" ] 
 then
    # deploy ingestion
-   echo "$CLUSTER_NAMESPACE - ingestion : Deploy via helm3"
-   date
    helm3 install $HELM_RELEASE . -f clinical_ingestion.yaml --wait --timeout 6m0s
-   date
 fi
-
-# setup all the env vars for input to maven
-# FHIR Using INGRESS
-export FHIR_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/fhir
-export FHIR_PORT=
-echo "*************************************"
-echo FHIR server: $FHIR_IP$FHIR_PORT
-echo "*************************************"
-
-# FHIR DEID - using INGRESS
-export FHIR_DEID_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/fhir-deid
-export FHIR_DEID_PORT=
-echo "*************************************"
-echo FHIR DEID server: $FHIR_DEID_IP$FHIR_DEID_PORT
-echo "*************************************"
-
-# DEID - using INGRESS
-export DEID_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/deid
-export DEID_PORT=
-echo "*************************************"
-echo DEID server: $DEID_IP$DEID_PORT
-echo "*************************************"
-
-# NIFI - using INGRESS
-export NIFI_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/
-export NIFI_PORT=
-echo "*************************************"
-echo NIFI server: $NIFI_IP$NIFI_PORT
-echo "*************************************"
-
-# EXPOSE KAFKA Service using INGRESS
-export EXP_KAFKA_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/expose-kafka
-export EXP_KAFKA_PORT=
-echo "*************************************"
-echo EXPOSE KAFKA Service: $EXP_KAFKA_IP$EXP_KAFKA_PORTT
-echo "*************************************"
-
-# DEID Prep - using INGRESS
-export DEID_PREP_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/deid-prep
-export DEID_PREP_PORT=
-echo "*************************************"
-echo DEID-PREP server: $DEID_PREP_IP$DEID_PREP_PORT
-echo "*************************************"
-
-# TERM Services Prep - using INGRESS
-export TERM_PREP_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/term-services-prep
-export TERM_PREP_PORT=
-echo "*************************************"
-echo TERM-SERVICES-PREP server: $TERM_PREP_IP$TERM_PREP_PORT
-echo "*************************************"
-
-# ASCVD From FHIR Service - using INGRESS
-export ASCVD_FROM_FHIR_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/ascvd-from-fhir
-export ASCVD_FROM_FHIR_PORT=
-echo "*************************************"
-echo ASCVD-FROM-FHIR server: $ASCVD_FROM_FHIR_IP$ASCVD_FROM_FHIR_PORT
-echo "*************************************"
-
-# NLP Insights Service - using INGRESS
-export NLP_INSIGHTS_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/nlp-insights
-export NLP_INSIGHTS_PORT=
-echo "*************************************"
-echo NLP Insights server: $NLP_INSIGHTS_IP$NLP_INSIGHTS_PORT
-echo "*************************************"
 
 
 echo "*************************************"

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -28,10 +28,10 @@ thisdeploy=$CLUSTER_NAMESPACE
 ingest="clinical-ingestion"
 enrich="clinical-enrich"
 
-if [$thisdeploy = $enrich]
+if [ $thisdeploy = $enrich ]
 then
    export HELM_RELEASE=enrich
-elif [$thisdeploy = $ingest] 
+elif [ $thisdeploy = $ingest ] 
 then
    export HELM_RELEASE=ingestion
 fi
@@ -72,12 +72,12 @@ pwd
 sed -i -e "s/\&hostname replace-me/\&hostname $TEST_NAMESPACE.$INGRESS_SUBDOMAIN/g" values.yaml
 cat values.yaml | grep $TEST_NAMESPACE.$INGRESS_SUBDOMAIN
 
-if [$thisdeploy = $enrich] 
+if [ $thisdeploy = $enrich ] 
 then
    # deploy enrich
    echo "$CLUSTER_NAMESPACE - enrich : Deploy via helm3  using Ingress"
    helm3 install $HELM_RELEASE . -f clinical_enrichment.yaml --set ascvd-from-fhir.ingress.enabled=true --set deid-prep.ingress.enabled=true --set term-services-prep.ingress.enabled=true --set nlp-insights.enabled=true --set nlp-insights.ingress.enabled=true --set nlp-insights.nlpservice.quickumls.endpoint=https://quickumls.wh-health-patterns.dev.watson-health.ibm.com/match --set nlp-insights.nlpservice.acd.endpoint=https://us-east.wh-acd.cloud.ibm.com/wh-acd/api --set nlp-insights.nlpservice.acd.apikey=$ACD_APIKEY --set nlp-insights.nlpservice.acd.flow=wh_acd.ibm_clinical_insights_v1.0_standard_flow --wait --timeout 6m0s
-elif [$thisdeploy = $ingest] 
+elif [ $thisdeploy = $ingest ] 
 then
    # deploy ingestion
    echo "$CLUSTER_NAMESPACE - ingestion : Deploy via helm3  using Ingress"
@@ -151,7 +151,7 @@ echo NLP Insights server: $NLP_INSIGHTS_IP$NLP_INSIGHTS_PORT
 echo "*************************************"
 
 # Wait for deployment to be ready
-if [$thisdeploy = $enrich] 
+if [ $thisdeploy = $enrich ] 
 then 
    echo "*************************************"
    echo "* Waiting for 2 minutes             *"
@@ -159,7 +159,7 @@ then
    date
    sleep 120  
    date   
-elif [$thisdeploy = $ingest] 
+elif [ $thisdeploy = $ingest ] 
 then 
    echo "*************************************"
    echo "* Waiting for 5 minutes             *"
@@ -174,7 +174,7 @@ echo "* A Look At Everything              *"
 echo "*************************************"
 kubectl get all
 
-if [$thisdeploy = $enrich] 
+if [ $thisdeploy = $enrich ] 
 then 
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"
@@ -214,7 +214,7 @@ then
    echo "<testsuites>" > /workspace/clinical-enrichment/tests/smoketests.xml
    cat target/surefire-reports/*.xml >> /workspace/clinical-enrichment/tests/smoketests.xml
    echo "</testsuites>" >> /workspace/clinical-enrichment/tests/smoketests.xml
-elif [$thisdeploy = $ingest] 
+elif [ $thisdeploy = $ingest ] 
 then
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -248,7 +248,7 @@ then
    echo "*************************************"
    echo "<testsuites>" > /workspace/clinical-enrichment/tests/smoketests.xml
    cat target/surefire-reports/*.xml >> /workspace/clinical-enrichment/tests/smoketests.xml
-   echo "</testsuites>" >> /workspace/ingest/clinical-enrichment/smoketests.xml
+   echo "</testsuites>" >> /workspace/clinical-enrichment/smoketests.xml
 fi
 
 

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -26,10 +26,10 @@ export INGRESS_SUBDOMAIN=wh-health-patterns.dev.watson-health.ibm.com
 
 cns = $CLUSTER_NAMESPACE
 
-if [$cns=="clinical-enrich"]
+if [$cns -eq "clinical-enrich"]
 then
    export HELM_RELEASE=enrich
-elif [$cns=="clinical-ingestion"] 
+elif [$cns -eq "clinical-ingestion"] 
 then
    export HELM_RELEASE=ingestion
 fi
@@ -70,12 +70,12 @@ pwd
 sed -i -e "s/\&hostname replace-me/\&hostname $TEST_NAMESPACE.$INGRESS_SUBDOMAIN/g" values.yaml
 cat values.yaml | grep $TEST_NAMESPACE.$INGRESS_SUBDOMAIN
 
-if [$cns=="clinical-enrich"] 
+if [$cns -eq "clinical-enrich"] 
 then
    # deploy enrich
    echo "$CLUSTER_NAMESPACE - enrich : Deploy via helm3  using Ingress"
    helm3 install $HELM_RELEASE . -f clinical_enrichment.yaml --set ascvd-from-fhir.ingress.enabled=true --set deid-prep.ingress.enabled=true --set term-services-prep.ingress.enabled=true --set nlp-insights.enabled=true --set nlp-insights.ingress.enabled=true --set nlp-insights.nlpservice.quickumls.endpoint=https://quickumls.wh-health-patterns.dev.watson-health.ibm.com/match --set nlp-insights.nlpservice.acd.endpoint=https://us-east.wh-acd.cloud.ibm.com/wh-acd/api --set nlp-insights.nlpservice.acd.apikey=$ACD_APIKEY --set nlp-insights.nlpservice.acd.flow=wh_acd.ibm_clinical_insights_v1.0_standard_flow --wait --timeout 6m0s
-elif [$cns=="clinical-ingestion"] 
+elif [$cns -eq "clinical-ingestion"] 
 then
    # deploy ingestion
    echo "$CLUSTER_NAMESPACE - ingestion : Deploy via helm3  using Ingress"
@@ -149,7 +149,7 @@ echo NLP Insights server: $NLP_INSIGHTS_IP$NLP_INSIGHTS_PORT
 echo "*************************************"
 
 # Wait for deployment to be ready
-if [$cns=="clinical-enrich"] 
+if [$cns -eq "clinical-enrich"] 
 then 
    echo "*************************************"
    echo "* Waiting for 2 minutes             *"
@@ -157,7 +157,7 @@ then
    date
    sleep 120  
    date   
-elif [$cns=="clinical-ingestion"] 
+elif [$cns -eq "clinical-ingestion"] 
 then 
    echo "*************************************"
    echo "* Waiting for 5 minutes             *"
@@ -172,7 +172,7 @@ echo "* A Look At Everything              *"
 echo "*************************************"
 kubectl get all
 
-if [$cns=="clinical-enrich"] 
+if [$cns -eq "clinical-enrich"] 
 then 
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"
@@ -212,7 +212,7 @@ then
    echo "<testsuites>" > /workspace/clinical-enrichment/tests/smoketests.xml
    cat target/surefire-reports/*.xml >> /workspace/clinical-enrichment/tests/smoketests.xml
    echo "</testsuites>" >> /workspace/clinical-enrichment/tests/smoketests.xml
-elif [$cns=="clinical-ingestion"] 
+elif [$cns -eq "clinical-ingestion"] 
 then
    echo "****************************************************" 
    echo "* Goto the testcase folder in the repo             *"

--- a/clinical-enrichment/tests/tests/run-smoketests.sh
+++ b/clinical-enrichment/tests/tests/run-smoketests.sh
@@ -4,6 +4,7 @@
 #
 # Run the enrich/ingestion smoke tests and add test results to smoketests.xml for the Insights Quality Dashboard
 
+# Setup the test environment
 chmod +x ./tests/toolchain-envsetup.sh
 source ./tests/toolchain-envsetup.sh "smoke"
 
@@ -41,8 +42,6 @@ then
    echo "* Goto the testcase folder in the repo             *"
    echo "****************************************************"
    cd /workspace/$TEST_NAMESPACE/health-patterns/clinical-enrichment/
-   pwd
-   ls
 
    echo "*************************************" 
    echo "* Build the testcases               *"
@@ -69,8 +68,6 @@ then
    echo "* Goto the testcase folder in the repo             *"
    echo "****************************************************"
    cd /workspace/$TEST_NAMESPACE/health-patterns/ingest/
-   pwd
-   ls
    
    echo "*************************************" 
    echo "* Build the testcases               *"

--- a/clinical-enrichment/tests/tests/toolchain-envsetup.sh
+++ b/clinical-enrichment/tests/tests/toolchain-envsetup.sh
@@ -24,11 +24,11 @@ export TEST_NAMESPACE=$CLUSTER_NAMESPACE"-"$1
 export INGRESS_SUBDOMAIN=wh-health-patterns.dev.watson-health.ibm.com 
 
 # Set the deploymemt-specific variables/values
-if [ $CLUSER_NAMESPACE = "clinical-enrich" ]
+if [ $CLUSTER_NAMESPACE = "clinical-enrich" ]
 then
    export HELM_RELEASE=enrich
    export deploywait=120
-elif [ $CLUSER_NAMESPACE = "clinical-ingestion" ] 
+elif [ $CLUSTER_NAMESPACE = "clinical-ingestion" ] 
 then
    export HELM_RELEASE=ingestion
    export deploywait=300

--- a/clinical-enrichment/tests/tests/toolchain-envsetup.sh
+++ b/clinical-enrichment/tests/tests/toolchain-envsetup.sh
@@ -77,11 +77,25 @@ echo "*************************************"
 echo FHIR server: $FHIR_IP$FHIR_PORT
 echo "*************************************"
 
+# FHIR PROXY Using INGRESS
+export FHIR_PROXY_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/fhir-proxy
+export FHIR__PROXY_PORT=
+echo "*************************************"
+echo FHIR Proxy server: $FHIR_PROXY_IP$FHIR_PROXY_PORT
+echo "*************************************"
+
 # FHIR DEID - using INGRESS
 export FHIR_DEID_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/fhir-deid
 export FHIR_DEID_PORT=
 echo "*************************************"
 echo FHIR DEID server: $FHIR_DEID_IP$FHIR_DEID_PORT
+echo "*************************************"
+
+# FHIR DEID PROXY- using INGRESS
+export FHIR_DEID_PROXY_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/fhir-deid-proxy
+export FHIR_DEID_PROXY_PORT=
+echo "*************************************"
+echo FHIR DEID PROXY server: $FHIR_DEID_PROXY_IP$FHIR_DEID_PROXY_PORT
 echo "*************************************"
 
 # DEID - using INGRESS

--- a/clinical-enrichment/tests/tests/toolchain-envsetup.sh
+++ b/clinical-enrichment/tests/tests/toolchain-envsetup.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+
+# Common toolchain setup code for smoketests, fvttests, and ivttest scripts
+# Input is test type (smoke, fvt, or ivt
+
+echo "*************************************"
+echo "* Linux version                     *"
+echo "*************************************"
+cat /etc/redhat-release
+
+echo "*************************************"
+echo "* Current Directory                 *"
+echo "*************************************"
+pwd
+
+echo "*************************************"
+echo "* Set Test env variables            *"
+echo "*************************************"
+export DEFAULT_PASSWORD=integrati0n
+export JAVA_HOME=/usr/lib/jvm/java-1.8.0
+export TEST_NAMESPACE=$CLUSTER_NAMESPACE"-"$1
+
+#This is for VPC cluster health-patterns-1
+export INGRESS_SUBDOMAIN=wh-health-patterns.dev.watson-health.ibm.com 
+
+# Set the deploymemt-specific variables/values
+if [ $CLUSER_NAMESPACE = "clinical-enrich" ]
+then
+   export HELM_RELEASE=enrich
+   export deploywait=120
+elif [ $CLUSER_NAMESPACE = "clinical-ingestion" ] 
+then
+   export HELM_RELEASE=ingestion
+   export deploywait=300
+fi
+
+echo "*************************************"
+echo "* setup base directory for test     *"
+echo "*************************************"
+cd /workspace
+mkdir $TEST_NAMESPACE
+cd $TEST_NAMESPACE
+
+echo "*************************************"
+echo "* create namespace and set to it    *"
+echo "*************************************"
+kubectl create namespace $TEST_NAMESPACE
+
+echo " Set namespace to $TEST_NAMESPACE"
+kubectl config set-context --current --namespace=$TEST_NAMESPACE
+
+echo "*************************************"
+echo "* Fetch the Code from Repo          *"
+echo "*************************************"
+
+echo " clone clinical ingestion git repo using "$GIT_BRANCH " branch"
+git clone --branch $GIT_BRANCH https://github.com/Alvearie/health-patterns.git
+
+echo " change to the correct directory"
+cd health-patterns/helm-charts/health-patterns
+
+echo " helm dependency update"
+helm3 dependency update
+
+echo " Current Directory:"
+pwd
+
+# Add hostname to values.yaml
+sed -i -e "s/\&hostname replace-me/\&hostname $TEST_NAMESPACE.$INGRESS_SUBDOMAIN/g" values.yaml
+cat values.yaml | grep $TEST_NAMESPACE.$INGRESS_SUBDOMAIN
+
+# setup all the env vars for input to maven
+# FHIR Using INGRESS
+export FHIR_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/fhir
+export FHIR_PORT=
+echo "*************************************"
+echo FHIR server: $FHIR_IP$FHIR_PORT
+echo "*************************************"
+
+# FHIR DEID - using INGRESS
+export FHIR_DEID_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/fhir-deid
+export FHIR_DEID_PORT=
+echo "*************************************"
+echo FHIR DEID server: $FHIR_DEID_IP$FHIR_DEID_PORT
+echo "*************************************"
+
+# DEID - using INGRESS
+export DEID_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/deid
+export DEID_PORT=
+echo "*************************************"
+echo DEID server: $DEID_IP$DEID_PORT
+echo "*************************************"
+
+# NIFI - using INGRESS
+export NIFI_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/
+export NIFI_PORT=
+echo "*************************************"
+echo NIFI server: $NIFI_IP$NIFI_PORT
+echo "*************************************"
+
+# EXPOSE KAFKA Service using INGRESS
+export EXP_KAFKA_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/expose-kafka
+export EXP_KAFKA_PORT=
+echo "*************************************"
+echo EXPOSE KAFKA Service: $EXP_KAFKA_IP$EXP_KAFKA_PORTT
+echo "*************************************"
+
+# DEID Prep - using INGRESS
+export DEID_PREP_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/deid-prep
+export DEID_PREP_PORT=
+echo "*************************************"
+echo DEID-PREP server: $DEID_PREP_IP$DEID_PREP_PORT
+echo "*************************************"
+
+# TERM Services Prep - using INGRESS
+export TERM_PREP_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/term-services-prep
+export TERM_PREP_PORT=
+echo "*************************************"
+echo TERM-SERVICES-PREP server: $TERM_PREP_IP$TERM_PREP_PORT
+echo "*************************************"
+
+# ASCVD From FHIR Service - using INGRESS
+export ASCVD_FROM_FHIR_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/ascvd-from-fhir
+export ASCVD_FROM_FHIR_PORT=
+echo "*************************************"
+echo ASCVD-FROM-FHIR server: $ASCVD_FROM_FHIR_IP$ASCVD_FROM_FHIR_PORT
+echo "*************************************"
+
+# NLP Insights Service - using INGRESS
+export NLP_INSIGHTS_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/nlp-insights
+export NLP_INSIGHTS_PORT=
+echo "*************************************"
+echo NLP Insights server: $NLP_INSIGHTS_IP$NLP_INSIGHTS_PORT
+echo "*************************************"

--- a/clinical-enrichment/tests/tests/toolchain-envsetup.sh
+++ b/clinical-enrichment/tests/tests/toolchain-envsetup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Common toolchain setup code for smoketests, fvttests, and ivttest scripts
-# Input is test type (smoke, fvt, or ivt
+# Input is test type (smoke, fvt, or ivt)
 
 echo "*************************************"
 echo "* Linux version                     *"


### PR DESCRIPTION
Refactor the enrich test scripts execute the common setup steps in a separate script (toolchain-envsetup.sh).
Add logic to execute enrich tests or ingest tests based on the cluster namespace (clinicial-enrich OR clinical-ingestion)