### PR TITLE
Issue #291 - Improved startup logging

### DIFF
--- a/services/expose-kafka/exposekafka.py
+++ b/services/expose-kafka/exposekafka.py
@@ -9,6 +9,7 @@ from flask import jsonify
 
 from datetime import datetime
 import time
+import logging
 
 app = Flask(__name__)
 
@@ -33,6 +34,8 @@ else:
 init_topics = initial_topics.replace(",", " ")
 topiclist = init_topics.split()
 
+app.logger.setLevel(logging.INFO)
+app.logger.info("Attempting to connect to Kafka server")
 last_recorded_time = round(time.time() * 1000)
 while True:
     try:

--- a/services/expose-kafka/exposekafka.py
+++ b/services/expose-kafka/exposekafka.py
@@ -43,14 +43,15 @@ while True:
         current_time = round(time.time() * 1000)
         # If the Kafka server isn't up for any reason, we'll print a message every minute until it comes up.
         if current_time - last_recorded_time > 60 * 1000:
-            print(f"Unable to connect Kafka server: {e}")
+            app.logger.exception(f"Unable to connect Kafka server: {e}")
+            app.logger.warn("Retrying connection to Kafka server...")
             last_recorded_time = current_time
         # Even though we only print a message every 60 seconds, we'll try to connect every 5 seconds
         # to minimize container startup time.
         time.sleep(5)
 
 # kafka is now up and running
-print("Connected to Kafka server")
+app.logger.info("Connected to Kafka server")
 
 initconsumer = KafkaConsumer(bootstrap_servers=kafkabootstrap,
                          sasl_mechanism="PLAIN", sasl_plain_username=kafkauser, sasl_plain_password=kafkapw)

--- a/services/expose-kafka/exposekafka.py
+++ b/services/expose-kafka/exposekafka.py
@@ -46,8 +46,8 @@ while True:
         current_time = round(time.time() * 1000)
         # If the Kafka server isn't up for any reason, we'll print a message every minute until it comes up.
         if current_time - last_recorded_time > 60 * 1000:
-            app.logger.exception(f"Unable to connect Kafka server: {e}")
-            app.logger.warn("Retrying connection to Kafka server...")
+            app.logger.error(f"Unable to connect Kafka server: {e}")
+            app.logger.info("Retrying connection to Kafka server...")
             last_recorded_time = current_time
         # Even though we only print a message every 60 seconds, we'll try to connect every 5 seconds
         # to minimize container startup time.


### PR DESCRIPTION
Here's an approach to improve startup logging the expose-kafka service.

Of note, these changes don't actually address pod readiness (which I'll open a separate issue for).  But now at least when the backing Kafka server is down, there is an error logged that indicates the problem.

I set the log level of the Flask logger to INFO in the code.  That might be a bit controversial, but it didn't seem to result in excessive logging when items were placed on the Kafka queue.