### PR TITLE
Add Clean Up Flag To Toolchain

### DIFF
--- a/test-umbrella/tests/tests/run-fvttests.sh
+++ b/test-umbrella/tests/tests/run-fvttests.sh
@@ -117,28 +117,33 @@ echo "<testsuites>" > /workspace/test-umbrella/tests/fvttest.xml
 cat target/surefire-reports/*.xml >> /workspace/test-umbrella/tests/fvttest.xml
 echo "</testsuites>" >> /workspace/test-umbrella/tests/fvttest.xml
 
-# then clean up
-echo "*************************************"
-echo "* Delete the Deployment             *"
-echo "*************************************"
-helm3 delete $HELM_RELEASE
-echo "*************************************"
-echo "* Waiting for 30  seconds           *"
-echo "*************************************"
-date
-sleep 30   
-date
-echo "*************************************"
-echo "* Delete NifiKop                    *"
-echo "*************************************"
-helm3 delete nifikop
-echo "*************************************"
-echo "* Waiting for 30  seconds           *"
-echo "*************************************"
-date
-sleep 30  
-date
-echo "*************************************"
-echo "* Delete Namespace                  *"
-echo "*************************************"
-kubectl delete namespace $TEST_NAMESPACE
+# ENV_CLEAN_UP is set in the toolchain environment properties.  The default value is true, but it can be changed on toolchain start
+# if we need to keep the test environment available for debug
+if [ $ENV_CLEAN_UP = "true" ]  
+then
+	# then clean up
+	echo "*************************************"
+	echo "* Delete the Deployment             *"
+	echo "*************************************"
+	helm3 delete $HELM_RELEASE
+	echo "*************************************"
+	echo "* Waiting for 30  seconds           *"
+	echo "*************************************"
+	date
+	sleep 30   
+	date
+	echo "*************************************"
+	echo "* Delete NifiKop                    *"
+	echo "*************************************"
+	helm3 delete nifikop
+	echo "*************************************"
+	echo "* Waiting for 30  seconds           *"
+	echo "*************************************"
+	date
+	sleep 30  
+	date
+	echo "*************************************"
+	echo "* Delete Namespace                  *"
+	echo "*************************************"
+	kubectl delete namespace $TEST_NAMESPACE
+fi	

--- a/test-umbrella/tests/tests/run-fvttests.sh
+++ b/test-umbrella/tests/tests/run-fvttests.sh
@@ -145,5 +145,10 @@ then
 	echo "*************************************"
 	echo "* Delete Namespace                  *"
 	echo "*************************************"
-	kubectl delete namespace $TEST_NAMESPACE
-fi	
+	kubectl delete namespace $TEST_NAMESPACE	
+else
+    # save the test deployment
+	echo "*************************************************************"
+	echo "* Test deployment "$HELM_RELEASE" in "$TEST_NAMESPACE" saved            *"
+	echo "*************************************************************"
+fi

--- a/test-umbrella/tests/tests/run-ivttests.sh
+++ b/test-umbrella/tests/tests/run-ivttests.sh
@@ -152,4 +152,9 @@ then
 	echo "* Delete Namespace                  *"
 	echo "*************************************"
 	kubectl delete namespace $TEST_NAMESPACE
+else 
+    # save the test deployment
+	echo "*************************************************************"
+	echo "* Test deployment "$HELM_RELEASE" in "$TEST_NAMESPACE" saved            *"
+	echo "*************************************************************"	
 fi	

--- a/test-umbrella/tests/tests/run-ivttests.sh
+++ b/test-umbrella/tests/tests/run-ivttests.sh
@@ -123,28 +123,33 @@ echo "<testsuites>" > /workspace/test-umbrella/tests/ivttest.xml
 cat target/surefire-reports/*.xml >> /workspace/test-umbrella/tests/ivttest.xml
 echo "</testsuites>" >> /workspace/test-umbrella/tests/ivttest.xml
 
-# then clean up
-echo "*************************************"
-echo "* Delete the Deployment             *"
-echo "*************************************"
-helm3 delete $HELM_RELEASE
-echo "*************************************"
-echo "* Waiting for 30  seconds           *"
-echo "*************************************"
-date
-sleep 30  
-date
-echo "*************************************"
-echo "* Delete NifiKop                    *"
-echo "*************************************"
-helm3 delete nifikop
-echo "*************************************"
-echo "* Waiting for 30  seconds           *"
-echo "*************************************"
-date
-sleep 30 
-date
-echo "*************************************"
-echo "* Delete Namespace                  *"
-echo "*************************************"
-kubectl delete namespace $TEST_NAMESPACE
+# ENV_CLEAN_UP is set in the toolchain environment properties.  The default value is true, but it can be changed on toolchain start
+# if we need to keep the test environment available for debug
+if [ $ENV_CLEAN_UP = "true" ]  
+then
+	# then clean up
+	echo "*************************************"
+	echo "* Delete the Deployment             *"
+	echo "*************************************"
+	helm3 delete $HELM_RELEASE
+	echo "*************************************"
+	echo "* Waiting for 30  seconds           *"
+	echo "*************************************"
+	date
+	sleep 30  
+	date
+	echo "*************************************"
+	echo "* Delete NifiKop                    *"
+	echo "*************************************"
+	helm3 delete nifikop
+	echo "*************************************"
+	echo "* Waiting for 30  seconds           *"
+	echo "*************************************"
+	date
+	sleep 30 
+	date
+	echo "*************************************"
+	echo "* Delete Namespace                  *"
+	echo "*************************************"
+	kubectl delete namespace $TEST_NAMESPACE
+fi	

--- a/test-umbrella/tests/tests/run-smoketests.sh
+++ b/test-umbrella/tests/tests/run-smoketests.sh
@@ -110,4 +110,9 @@ then
 	echo "*************************************"
 	helm3 delete $HELM_RELEASE
 	kubectl delete namespace $TEST_NAMESPACE
+else 
+    # save the test deployment
+	echo "*************************************************************"
+	echo "* Test deployment "$HELM_RELEASE" in "$TEST_NAMESPACE" saved            *"
+	echo "*************************************************************"
 fi

--- a/test-umbrella/tests/tests/run-smoketests.sh
+++ b/test-umbrella/tests/tests/run-smoketests.sh
@@ -100,10 +100,14 @@ echo "<testsuites>" > /workspace/test-umbrella/tests/smoketests.xml
 cat target/surefire-reports/*.xml >> /workspace/test-umbrella/tests/smoketests.xml
 echo "</testsuites>" >> /workspace/test-umbrella/tests/smoketests.xml
 
-# then clean up
-echo "*************************************"
-echo "* Delete the Deployment             *"
-echo "*************************************"
-helm3 delete $HELM_RELEASE
-kubectl delete namespace $TEST_NAMESPACE
-
+# ENV_CLEAN_UP is set in the toolchain environment properties.  The default value is true, but it can be changed on toolchain start
+# if we need to keep the test environment available for debug
+if [ $ENV_CLEAN_UP = "true" ]  
+then
+	# then clean up
+	echo "*************************************"
+	echo "* Delete the Deployment             *"
+	echo "*************************************"
+	helm3 delete $HELM_RELEASE
+	kubectl delete namespace $TEST_NAMESPACE
+fi


### PR DESCRIPTION
Add the ENV_CLEAN_UP flag as input to the toolchain run.  Default value is true, and it can be changed to false on a manual start of the toolchains to keep the deployments/namespaces for debug.