### PR TITLE
Remove unused port parameter as input to testcase builds

### DIFF
--- a/enrich/pom.xml
+++ b/enrich/pom.xml
@@ -71,65 +71,33 @@
                                 <value>${ip.fhir}</value>
                             </replacement>
                             <replacement>
-                                <token>@@port.fhir@@</token>
-                                <value>${port.fhir}</value>
-                            </replacement>
-                            <replacement>
                                 <token>@@ip.fhir.proxy@@</token>
                                 <value>${ip.fhir.proxy}</value>
-                            </replacement>
-                            <replacement>
-                                <token>@@port.fhir.proxy@@</token>
-                                <value>${port.fhir.proxy}</value>
                             </replacement>
                             <replacement>
                                 <token>@@ip.fhir.deid@@</token>
                                 <value>${ip.fhir.deid}</value>
                             </replacement>
                             <replacement>
-                                <token>@@port.fhir.deid@@</token>
-                                <value>${port.fhir.deid}</value>
-                            </replacement>
-                            <replacement>
                                 <token>@@ip.fhir.deid.proxy@@</token>
                                 <value>${ip.fhir.deid.proxy}</value>
-                            </replacement>
-                            <replacement>
-                                <token>@@port.fhir.deid.proxy@@</token>
-                                <value>${port.fhir.deid.proxy}</value>
-                            </replacement>                             
+                            </replacement>                            
                             <replacement>
                                 <token>@@ip.deid.prep@@</token>
                                 <value>${ip.deid.prep}</value>
                             </replacement>
-                            <replacement>
-                                <token>@@port.deid.prep@@</token>
-                                <value>${port.deid.prep}</value>
-                            </replacement>
                              <replacement>
                                 <token>@@ip.term.prep@@</token>
                                 <value>${ip.term.prep}</value>
-                            </replacement>
-                            <replacement>
-                                <token>@@port.term.prep@@</token>
-                                <value>${port.term.prep}</value>
                             </replacement>  
                              <replacement>
                                 <token>@@ip.ascvd.from.fhir@@</token>
                                 <value>${ip.ascvd.from.fhir}</value>
                             </replacement>
                             <replacement>
-                                <token>@@port.ascvd.from.fhir@@</token>
-                                <value>${port.ascvd.from.fhir}</value>
-                            </replacement> 
-                            <replacement>
                                 <token>@@ip.nlp.insights@@</token>
                                 <value>${ip.nlp.insights}</value>
-                            </replacement>
-                            <replacement>
-                                <token>@@port.nlp.insights@@</token>
-                                <value>${port.nlp.insights}</value>
-                            </replacement>                                                                           
+                            </replacement>                                                                          
                         </replacements>
                     </configuration>
     </plugin>

--- a/enrich/src/test/resources/enrich-flow.properties
+++ b/enrich/src/test/resources/enrich-flow.properties
@@ -1,19 +1,19 @@
 # PHI FHIR Server 
-pri_fhir_server=https://fhiruser:@@pw@@@@@ip.fhir@@@@port.fhir@@
-pri_fhir_proxy_server=https://@@ip.fhir..proxy@@@@port.fhir.proxy@@
+pri_fhir_server=https://fhiruser:@@pw@@@@@ip.fhir@@
+pri_fhir_proxy_server=https://@@ip.fhir.proxy@@
 
 # DEID FHIR Server
-deid_fhir_server=https://fhiruser:@@pw@@@@@ip.fhir.deid@@@@port.fhir.deid@@
-deid_fhir_proxy_server=https://@@ip.fhir.deid..proxy@@@@port.fhir.deid..proxy
+deid_fhir_server=https://fhiruser:@@pw@@@@@ip.fhir.deid@@
+deid_fhir_proxy_server=https://@@ip.fhir.deid.proxy@@
 
 # DEID Prep Service
-deid_prep=https://@@ip.deid.prep@@@@port.deid.prep@@
+deid_prep=https://@@ip.deid.prep@@
 
 # Terminology Prep Service 
-term_prep=https://@@ip.term.prep@@@@port.term.prep@@
+term_prep=https://@@ip.term.prep@@
 
 # ASCVD from FHIR Service
-ascvd_from_fhir=https://@@ip.ascvd.from.fhir@@@@port.ascvd.from.fhir@@
+ascvd_from_fhir=https://@@ip.ascvd.from.fhir@@
 
 # NLP-Insights Service
-nlp_insights=https://@@ip.nlp.insights@@@@port.nlp.insights@@
+nlp_insights=https://@@ip.nlp.insights@@

--- a/ingest/pom.xml
+++ b/ingest/pom.xml
@@ -71,80 +71,40 @@
                 <value>${ip.fhir}</value>
             </replacement>
             <replacement>
-				<token>@@port.fhir@@</token>
-                <value>${port.fhir}</value>
-            </replacement>
-            <replacement>
 				<token>@@ip.fhir.proxy@@</token>
                 <value>${ip.fhir.proxy}</value>
-            </replacement>
-            <replacement>
-				<token>@@port.fhir.proxy@@</token>
-                <value>${port.fhir.proxy}</value>
             </replacement>
             <replacement>
 				<token>@@ip.fhir.deid@@</token>
                 <value>${ip.fhir.deid}</value>
             </replacement>
             <replacement>
-				<token>@@port.fhir.deid@@</token>
-                <value>${port.fhir.deid}</value>
-            </replacement>
-            <replacement>
 				<token>@@ip.fhir.deid.proxy@@</token>
                 <value>${ip.fhir.deid.proxy}</value>
-            </replacement>
-            <replacement>
-				<token>@@port.fhir.deid.proxy@@</token>
-                <value>${port.fhir.deid.proxy}</value>
-            </replacement>                             
+            </replacement>                            
             <replacement>
 				<token>@@ip.deid@@</token>
                 <value>${ip.deid}</value>
-            </replacement>
-            <replacement>
-                <token>@@port.deid@@</token>
-                <value>${port.deid}</value>
-            </replacement>                           
+            </replacement>                         
             <replacement>
                 <token>@@ip.nifi@@</token>
                 <value>${ip.nifi}</value>
-            </replacement>
-            <replacement>
-                <token>@@port.nifi@@</token>
-                <value>${port.nifi}</value>
             </replacement>
             <replacement>
                 <token>@@ip.nifi.api@@</token>
                 <value>${ip.nifi.api}</value>
             </replacement>
             <replacement>
-                <token>@@port.nifi.api@@</token>
-                <value>${port.nifi.api}</value>
-            </replacement>
-            <replacement>
                 <token>@@ip.kafka@@</token>
                 <value>${ip.kafka}</value>
             </replacement>
             <replacement>
-                <token>@@port.kafka@@</token>
-                <value>${port.kafka}</value>
-            </replacement>
-            <replacement>
                 <token>@@ip.expkafka@@</token>
                 <value>${ip.expkafka}</value>
-            </replacement>
-            <replacement>
-                <token>@@port.expkafka@@</token>
-                <value>${port.expkafka}</value>
             </replacement>  
             <replacement>
                 <token>@@ip.nlp.insights@@</token>
                 <value>${ip.nlp.insights}</value>
-            </replacement>
-            <replacement>
-                <token>@@port.nlp.insights@@</token>
-                <value>${port.nlp.insights}</value>
             </replacement> 
             <replacement>
                 <token>@@kafka.topic.in@@</token>

--- a/ingest/src/test/resources/clinical-ingestion-flow.properties
+++ b/ingest/src/test/resources/clinical-ingestion-flow.properties
@@ -1,20 +1,20 @@
 # PHI FHIR Server 
-pri_fhir_server=https://fhiruser:@@pw@@@@@ip.fhir@@@@port.fhir@@
-pri_fhir_proxy_server=https://@@ip.fhir.proxy@@@@port.fhir.proxy@@
+pri_fhir_server=https://fhiruser:@@pw@@@@@ip.fhir@@
+pri_fhir_proxy_server=https://@@ip.fhir.proxy@@
 
 # DEID FHIR Server
-deid_fhir_server=https://fhiruser:@@pw@@@@@ip.fhir.deid@@@@port.fhir.deid@@
-deid_fhir_proxy_server=https://@@ip.fhir.deid.proxy@@@@port.fhir.deid.proxy@@
+deid_fhir_server=https://fhiruser:@@pw@@@@@ip.fhir.deid@@
+deid_fhir_proxy_server=https://@@ip.fhir.deid.proxy@@
 
 #DEID Service
-deid_service=https://@@ip.deid@@@@port.deid@@
+deid_service=https://@@ip.deid@@
 
 #NIFI Service
-nifi_server=https://@@ip.nifi@@@@port.nifi@@
+nifi_server=https://@@ip.nifi@@
 
 # Expose Kafka Service
-expose_kafka=https://@@ip.expkafka@@@@port.expkafka@@
+expose_kafka=https://@@ip.expkafka@@
 kafka.ingestion.topic=@@kafka.topic.in@@
 
 #NLP-Insights Service
-nlp_insights=https://@@ip.nlp.insights@@@@port.nlp.insights@@
+nlp_insights=https://@@ip.nlp.insights@@

--- a/test-umbrella/tests/tests/run-fvttests.sh
+++ b/test-umbrella/tests/tests/run-fvttests.sh
@@ -67,7 +67,7 @@ then
    echo "*************************************" 
    echo "* Build the testcases               *"
    echo "*************************************"
-   mvn clean install -e -Dip.fhir=$FHIR_IP -Dport.fhir=$FHIR_PORT -Dip.fhir.deid=$FHIR_DEID_IP -Dport.fhir.deid=$FHIR_DEID_PORT -Dip.deid.prep=$DEID_PREP_IP -Dport.deid.prep=$DEID_PREP_PORT -Dip.term.prep=$TERM_PREP_IP -Dport.term.prep=$TERM_PREP_PORT -Dip.ascvd.from.fhir=$ASCVD_FROM_FHIR_IP -Dport.ascvd.from.fhir=$ASCVD_FROM_FHIR_PORT -Dip.nlp.insights=$NLP_INSIGHTS_IP -Dport.nlp.insights=$NLP_INSIGHTS_PORT -Dpw=$DEFAULT_PASSWORD
+   mvn clean install -e -Dip.fhir=$FHIR_IP -Dip.fhir.deid=$FHIR_DEID_IP -Dip.deid.prep=$DEID_PREP_IP -Dip.term.prep=$TERM_PREP_IP -Dip.ascvd.from.fhir=$ASCVD_FROM_FHIR_IP -Dip.nlp.insights=$NLP_INSIGHTS_IP -Dpw=$DEFAULT_PASSWORD
 
    echo "*************************************" 
    echo "* Execute the testcases             *"
@@ -97,7 +97,7 @@ then
    echo "*************************************" 
    echo "* Build the testcases               *"
    echo "*************************************"
-   mvn clean install -e -Dip.fhir=$FHIR_IP -Dport.fhir=$FHIR_PORT -Dip.fhir.deid=$FHIR_DEID_IP -Dport.fhir.deid=$FHIR_DEID_PORT -Dip.nifi=$NIFI_IP -Dport.nifi=$NIFI_PORT -Dip.nifi.api=$NIFI_API_IP -Dport.nifi.api=$NIFI_API_PORT -Dip.kafka=$KAFKA_IP -Dport.nifi.api=$NIFI_API_PORT -Dip.deid=$DEID_IP -Dport.deid=$DEID_PORT -Dip.expkafka=$EXP_KAFKA_IP -Dport.expkafka=$EXP_KAFKA_PORT -Dkafka.topic.in=$KAFKA_TOPIC_IN -Dpw=$DEFAULT_PASSWORD
+   mvn clean install -e -Dip.fhir=$FHIR_IP -Dip.fhir.deid=$FHIR_DEID_IP -Dip.nifi=$NIFI_IP -Dip.nifi.api=$NIFI_API_IP -Dip.kafka=$KAFKA_IP -Dip.deid=$DEID_IP -Dip.expkafka=$EXP_KAFKA_IP -Dkafka.topic.in=$KAFKA_TOPIC_IN -Dpw=$DEFAULT_PASSWORD
 
    echo "*************************************" 
    echo "* Execute the initialize testcases  *"

--- a/test-umbrella/tests/tests/run-ivttests.sh
+++ b/test-umbrella/tests/tests/run-ivttests.sh
@@ -70,7 +70,7 @@ then
    echo "*************************************" 
    echo "* Build the testcases               *"
    echo "*************************************"
-   mvn clean install -e -Dip.fhir=$FHIR_IP -Dport.fhir=$FHIR_PORT -Dip.fhir.deid=$FHIR_DEID_IP -Dport.fhir.deid=$FHIR_DEID_PORT -Dip.deid.prep=$DEID_PREP_IP -Dport.deid.prep=$DEID_PREP_PORT -Dip.term.prep=$TERM_PREP_IP -Dport.term.prep=$TERM_PREP_PORT -Dip.ascvd.from.fhir=$ASCVD_FROM_FHIR_IP -Dport.ascvd.from.fhir=$ASCVD_FROM_FHIR_PORT -Dip.nlp.insights=$NLP_INSIGHTS_IP -Dport.nlp.insights=$NLP_INSIGHTS_PORT -Dpw=$DEFAULT_PASSWORD
+   mvn clean install -e -Dip.fhir=$FHIR_IP -Dip.fhir.deid=$FHIR_DEID_IP -Dip.deid.prep=$DEID_PREP_IP -Dip.term.prep=$TERM_PREP_IP -Dip.ascvd.from.fhir=$ASCVD_FROM_FHIR_IP -Dip.nlp.insights=$NLP_INSIGHTS_IP -Dpw=$DEFAULT_PASSWORD
 
    echo "*************************************" 
    echo "* Execute the testcases             *"
@@ -100,7 +100,7 @@ then
    echo "*************************************" 
    echo "* Build the testcases               *"
    echo "*************************************"
-   mvn clean install -e -Dip.fhir=$FHIR_IP -Dport.fhir=$FHIR_PORT -Dip.fhir.proxy=$FHIR_PROXY_IP -Dport.fhir.proxy=$FHIR__PROXY_PORT -Dip.fhir.deid=$FHIR_DEID_IP -Dport.fhir.deid=$FHIR_DEID_PORT -Dip.fhir.deid.proxy=$FHIR_DEID_PROXY_IP -Dport.fhir.deid.proxy=$FHIR_DEID_PROXY_PORT -Dip.deid=$DEID_IP -Dport.deid=$DEID_PORT -Dip.nifi=$NIFI_IP -Dport.nifi=$NIFI_PORT -Dip.expkafka=$EXP_KAFKA_IP -Dport.expkafka=$EXP_KAFKA_PORT -Dip.nlp.insights=$NLP_INSIGHTS_IP -Dport.nlp.insights=$NLP_INSIGHTS_PORT -Dkafka.topic.in=$KAFKA_TOPIC_IN -Dpw=$DEFAULT_PASSWORD
+   mvn clean install -e -Dip.fhir=$FHIR_IP -Dip.fhir.proxy=$FHIR_PROXY_IP -Dip.fhir.deid=$FHIR_DEID_IP -Dip.fhir.deid.proxy=$FHIR_DEID_PROXY_IP -Dip.deid=$DEID_IP -Dip.nifi=$NIFI_IP -Dip.expkafka=$EXP_KAFKA_IP -Dip.nlp.insights=$NLP_INSIGHTS_IP -Dkafka.topic.in=$KAFKA_TOPIC_IN -Dpw=$DEFAULT_PASSWORD
 
    echo "*************************************" 
    echo "* Initialize the testcases          *"

--- a/test-umbrella/tests/tests/run-smoketests.sh
+++ b/test-umbrella/tests/tests/run-smoketests.sh
@@ -58,7 +58,7 @@ then
    echo "*************************************" 
    echo "* Build the testcases               *"
    echo "*************************************"
-   mvn clean install -e -Dip.fhir=$FHIR_IP -Dport.fhir=$FHIR_PORT -Dip.fhir.deid=$FHIR_DEID_IP -Dport.fhir.deid=$FHIR_DEID_PORT -Dip.deid.prep=$DEID_PREP_IP -Dport.deid.prep=$DEID_PREP_PORT -Dip.term.prep=$TERM_PREP_IP -Dport.term.prep=$TERM_PREP_PORT -Dip.ascvd.from.fhir=$ASCVD_FROM_FHIR_IP -Dport.ascvd.from.fhir=$ASCVD_FROM_FHIR_PORT -Dip.nlp.insights=$NLP_INSIGHTS_IP -Dport.nlp.insights=$NLP_INSIGHTS_PORT -Dpw=$DEFAULT_PASSWORD
+   mvn clean install -e -Dip.fhir=$FHIR_IP -Dip.fhir.deid=$FHIR_DEID_IP -Dip.deid.prep=$DEID_PREP_IP -Dip.term.prep=$TERM_PREP_IP -Dip.ascvd.from.fhir=$ASCVD_FROM_FHIR_IP -Dip.nlp.insights=$NLP_INSIGHTS_IP -Dpw=$DEFAULT_PASSWORD
 
    echo "*************************************" 
    echo "* Execute the testcases             *"
@@ -84,7 +84,7 @@ then
    echo "*************************************" 
    echo "* Build the testcases               *"
    echo "*************************************"
-   mvn clean install -e -Dip.fhir=$FHIR_IP -Dport.fhir=$FHIR_PORT -Dip.fhir.deid=$FHIR_DEID_IP -Dport.fhir.deid=$FHIR_DEID_PORT -Dip.nifi=$NIFI_IP -Dport.nifi=$NIFI_PORT -Dip.nifi.api=$NIFI_API_IP -Dport.nifi.api=$NIFI_API_PORT -Dip.kafka=$KAFKA_IP -Dport.kafka=$KAFKA_PORT -Dip.deid=$DEID_IP -Dport.deid=$DEID_PORT -Dip.expkafka=$EXP_KAFKA_IP -Dport.expkafka=$EXP_KAFKA_PORT -Dkafka.topic.in=$KAFKA_TOPIC_IN -Dpw=$DEFAULT_PASSWORD
+   mvn clean install -e -Dip.fhir=$FHIR_IP -Dip.fhir.deid=$FHIR_DEID_IP -Dip.nifi=$NIFI_IP -Dip.nifi.api=$NIFI_API_IP -Dip.kafka=$KAFKA_IP -Dip.deid=$DEID_IP -Dip.expkafka=$EXP_KAFKA_IP -Dkafka.topic.in=$KAFKA_TOPIC_IN -Dpw=$DEFAULT_PASSWORD
 
    echo "*************************************" 
    echo "* Execute Initialize testcases      *"

--- a/test-umbrella/tests/tests/toolchain-envsetup.sh
+++ b/test-umbrella/tests/tests/toolchain-envsetup.sh
@@ -75,77 +75,66 @@ cat values.yaml | grep $TEST_NAMESPACE.$INGRESS_SUBDOMAIN
 # setup all the env vars for input to maven
 # FHIR Using INGRESS
 export FHIR_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/fhir
-export FHIR_PORT=
 echo "*************************************"
-echo FHIR server: $FHIR_IP$FHIR_PORT
+echo FHIR server: $FHIR_IP
 echo "*************************************"
 
 # FHIR PROXY Using INGRESS
 export FHIR_PROXY_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/fhir-proxy
-export FHIR__PROXY_PORT=
 echo "*************************************"
-echo FHIR Proxy server: $FHIR_PROXY_IP$FHIR_PROXY_PORT
+echo FHIR Proxy server: $FHIR_PROXY_IP
 echo "*************************************"
 
 # FHIR DEID - using INGRESS
 export FHIR_DEID_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/fhir-deid
-export FHIR_DEID_PORT=
 echo "*************************************"
-echo FHIR DEID server: $FHIR_DEID_IP$FHIR_DEID_PORT
+echo FHIR DEID server: $FHIR_DEID_IP
 echo "*************************************"
 
 # FHIR DEID PROXY- using INGRESS
 export FHIR_DEID_PROXY_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/fhir-deid-proxy
-export FHIR_DEID_PROXY_PORT=
 echo "*************************************"
-echo FHIR DEID PROXY server: $FHIR_DEID_PROXY_IP$FHIR_DEID_PROXY_PORT
+echo FHIR DEID PROXY server: $FHIR_DEID_PROXY_IP
 echo "*************************************"
 
 # DEID - using INGRESS
 export DEID_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/deid
-export DEID_PORT=
 echo "*************************************"
-echo DEID server: $DEID_IP$DEID_PORT
+echo DEID server: $DEID_IP
 echo "*************************************"
 
 # NIFI - using INGRESS
 export NIFI_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/
-export NIFI_PORT=
 echo "*************************************"
-echo NIFI server: $NIFI_IP$NIFI_PORT
+echo NIFI server: $NIFI_IP
 echo "*************************************"
 
 # EXPOSE KAFKA Service using INGRESS
 export EXP_KAFKA_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/expose-kafka
-export EXP_KAFKA_PORT=
 echo "*************************************"
-echo EXPOSE KAFKA Service: $EXP_KAFKA_IP$EXP_KAFKA_PORTT
+echo EXPOSE KAFKA Service: $EXP_KAFKA_IP
 echo "*************************************"
 
 # DEID Prep - using INGRESS
 export DEID_PREP_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/deid-prep
-export DEID_PREP_PORT=
 echo "*************************************"
-echo DEID-PREP server: $DEID_PREP_IP$DEID_PREP_PORT
+echo DEID-PREP server: $DEID_PREP_IP
 echo "*************************************"
 
 # TERM Services Prep - using INGRESS
 export TERM_PREP_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/term-services-prep
-export TERM_PREP_PORT=
 echo "*************************************"
-echo TERM-SERVICES-PREP server: $TERM_PREP_IP$TERM_PREP_PORT
+echo TERM-SERVICES-PREP server: $TERM_PREP_IP
 echo "*************************************"
 
 # ASCVD From FHIR Service - using INGRESS
 export ASCVD_FROM_FHIR_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/ascvd-from-fhir
-export ASCVD_FROM_FHIR_PORT=
 echo "*************************************"
-echo ASCVD-FROM-FHIR server: $ASCVD_FROM_FHIR_IP$ASCVD_FROM_FHIR_PORT
+echo ASCVD-FROM-FHIR server: $ASCVD_FROM_FHIR_IP
 echo "*************************************"
 
 # NLP Insights Service - using INGRESS
 export NLP_INSIGHTS_IP=$TEST_NAMESPACE.$INGRESS_SUBDOMAIN/nlp-insights
-export NLP_INSIGHTS_PORT=
 echo "*************************************"
-echo NLP Insights server: $NLP_INSIGHTS_IP$NLP_INSIGHTS_PORT
+echo NLP Insights server: $NLP_INSIGHTS_IP
 echo "*************************************"


### PR DESCRIPTION
Signed-off-by: Roger Guderian <roger.guderian@ibm.com>

Removing input the port parameter from each of the service URLs since it is not used. 