### PR TITLE
Atc default to nifikop

### DIFF
--- a/enrich/README.md
+++ b/enrich/README.md
@@ -157,41 +157,6 @@ After running the command above, you will see notes that give you information ab
 **IMPORTANT NOTE** The release name for the enrichment pipeline must be **enrich** (see [Advanced topics](#advanced-topics) for additional information)
 
 
-#### Alternative deployment instructions (insecure)
-
-The instructions listed above are the recommended steps for deploying Health Patterns Enrichment flow. However, it requires sufficient authority to the target cluster to deploy Custom Resource Definitions and configure an OIDC service. If these authorities are not attainable it may be necessary to deploy an unsecured, non-authenticating version of Enrichment.
-
-**NOTE:** Given the significant differences between the Nifikop-based deployment and this, it is not feasible to maintain both approaches targeting current Nifi dataflows. Therefore, using the insecure deployment will result in a snapshot of these flows current as of November 2021, but not updated since.
-
-First, setup deployment parameters:
-
-1) Update your ingress parameters as noted [here](#ingress-parameters).
-
-2) Update values.yaml with the following changes:
-
-```
-nifikop:
-  disabled: &nifikopDisabled true
-  enabled: &nifikopEnabled false
-```
-
-NOTE: Due to a limitation in Helm, when using the Health Patterns chart with a release name other than the defaults of `enrich`, you are required to update the clinical_enrichment.yaml file to correspond to the correct release name and bootstrapServers.
-
-```
-nifi:
-  extraContainers:
-    - name: post-start-setup
-      env:
-      - name: "RELEASE_NAME"
-        value: "enrich"
-
-fhir:
-  notifications:
-    kafka:
-      bootstrapServers: "enrich-kafka:9092"
-```
-
-
 Finally, to deploy run:
 
 `helm install enrich. -f clinical_enrichment.yaml`
@@ -289,27 +254,46 @@ Note that if the enrichment pattern is being used as part of the ingestion patte
 converted to FHIR (by ingestion) before it is allowed to run through the enrichment pipeline.
 Other data types (such as DICOM image data) are being considered but are currently not supported.
 
-#### Alternate configuration for Helm Chart
+
+#### Alternative deployment instructions (insecure)
+
+The instructions listed above are the recommended steps for deploying Health Patterns Enrichment flow. However, it requires sufficient authority to the target cluster to deploy Custom Resource Definitions and configure an OIDC service. If these authorities are not attainable it may be necessary to deploy an unsecured, non-authenticating version of Enrichment.
+
+**NOTE:** Given the significant differences between the Nifikop-based deployment and this, it is not feasible to maintain both approaches targeting current Nifi dataflows. Therefore, using the insecure deployment will result in a snapshot of these flows current as of November 2021, but not updated since.
+
+First, setup deployment parameters:
+
+1) Update your ingress parameters as noted [here](#ingress-parameters).
+
+2) Update values.yaml with the following changes:
+
+```
+nifikop:
+  disabled: &nifikopDisabled true
+  enabled: &nifikopEnabled false
+```
+
+**NOTE:** Due to a limitation in Helm, when using the Health Patterns chart with a release name other than the defaults of `enrich`, you are required to update the clinical_enrichment.yaml file to correspond to the correct release name and bootstrapServers.
+
+```
+nifi:
+  extraContainers:
+    - name: post-start-setup
+      env:
+      - name: "RELEASE_NAME"
+        value: "enrich"
+
+fhir:
+  notifications:
+    kafka:
+      bootstrapServers: "enrich-kafka:9092"
+```
+
+
+#### Advanced configuration for Helm Chart
 
 When deploying this chart, there are many configuration parameters specified in the values.yaml file.  These can all be overridden based on individual preferences.  To do so, you can create a secondary YAML file containing your changes and specify it to the `helm install` command to override default configuration.
 
-```
-helm install <<RELEASE_NAME>> . \
-    -f value_overrides.yaml \
-    -f clinical_enrichment.yaml
-```
+`helm install enrich . -f value_overrides.yaml`
 
 **NOTE:** You can chain multiple override file parameters in yaml, so if you want to deploy the load balancer values as well as other overrides, just specify each using another "-f" parameter.
-
-**NOTE:** Due to a limitation in Helm, when using the Health Patterns chart with a release name other than the defaults of `enrich`, you are required to update the corresponding values.yaml file to have the correct release name.  
-
-For enrichment, update the `RELEASE_NAME` environment variable in the `clinical_enrichment.yaml` file.  The value should be changed from _enrich_ to whatever release name you choose.
-
-```
-env:
-- name: "RELEASE_NAME"
-  value: "enrich"
-```
-
-In that same file, update the line
-- `bootstrapServers: "enrich-kafka:9092"` to include the correct Kafka broker, replacing _enrich_ with the correct release name.

--- a/enrich/README.md
+++ b/enrich/README.md
@@ -40,6 +40,9 @@ These instructions assume that you have the following resources, tools, and conf
 - Access to ```kubectl```, the Kubernetes command line tool
 - PV provisioner support in the underlying infrastructure
 
+**Note:** If you don't have access to a kubernetes cluster, this pattern can also be [deployed to minikube](../helm-charts/health-patterns/README_minikube.md).
+
+
 #### Check out the code
 
 ```
@@ -58,6 +61,51 @@ Please note that although this is step is optional, it is highly recommended tha
 kubectl create namespace alvearie
 kubectl config set-context --current --namespace=alvearie
 ```
+
+**NOTE:** The length of a namespace name must be less than or equal to **20 characters**.  Using a name that is longer than 20 characters will result in a failure to deploy the Nifi pod due to a certificate issue (the error will be visible in the NifiKop log).
+
+### Configure Nifikop
+
+This chart relies on [NifiKop](https://orange-opensource.github.io/nifikop/) to deploy Apache Nifi.  This relies on a one-time setup for your cluster to install the Custom Resource Definitions properly.  See [Getting Started](https://orange-opensource.github.io/nifikop/docs/2_setup/1_getting_started) for instructions on how to setup your cluster.
+
+In addition, using NifiKop requires a NifiKop controller to be deployed in the namespace prior to deploying the Health Patterns Helm chart.  This allows the NifiKop custom resources to be managed correctly, and by deploying separately guarantees the controller remains active when custom resources are deleted, allowing proper clean-up.
+
+To deploy a NifiKop controller to your namespace, run:
+
+```
+helm repo add orange-incubator https://orange-kubernetes-charts-incubator.storage.googleapis.com/
+
+helm repo update
+
+helm install nifikop \
+    orange-incubator/nifikop \
+    --namespace=<<NAMESPACE>> \
+    --version 0.7.1 \
+    --set image.tag=v0.7.1-release \
+    --set resources.requests.memory=256Mi \
+    --set resources.requests.cpu=250m \
+    --set resources.limits.memory=256Mi \
+    --set resources.limits.cpu=250m \
+    --set namespaces={"<<NAMESPACE>>"}
+```
+
+### User Authentication - OpenID Connect
+
+Nifikop configures a secure Nifi instance which relies on [OIDC](https://openid.net/connect/) to authenticate user access.  This requires you to separately setup an OIDC service and supply the correct configuration information to this Helm chart.  For example, [App Id](https://www.ibm.com/cloud/app-id) is available for IBM Cloud instances.
+
+Once configured, update the values.yaml to populate the following parameters.
+
+```
+oidc:
+  users - a list of identity/name values representing the user(s) you want configured for access.  The identity must match the login identity from your OIDC endpoint, and the name should be lower-case and contain no spaces.
+  discovery:
+    url - The URL of your OIDC discovery service
+  client:
+    id - The client ID of your OIDC discovery service
+    secret - The client secret of your OIDC discovery service
+```
+
+**NOTE:** You will also need to register your OIDC callback (`https://<<HOST_NAME>>:443/nifi-api/access/oidc/callback`) with your OIDC service.  For IBM App ID, this is located under Manage Authentication->Authentication Settings->Add Web Redirect URLs.
 
 #### Ingress parameters
 
@@ -89,14 +137,48 @@ ingress:
 ```
 
 
+### Storage class
+And finally, if you are deploying to a non-IBM cloud, you will need to change the storage class used by Nifi by updating the following parameter:
+
+```
+nifi2:
+  storageClassName - The storage class you wish to use for persisting Nifi.
+```
+
 #### Deployment
 The following Helm command will deploy the enrichment pattern.  The enrichment pipeline will be ready to accept FHIR data and run it through a series of steps producing a possibly updated FHIR bundle with resources that have been added or modified by the enrichment process.
 ```
-helm install enrich .  -f clinical_enrichment.yaml
+helm install enrich .
 ```
+
 After running the command above, you will see notes that give you information about the deployment, in particular, where the important services (e.g. Nifi, expose-kafka) have been deployed.
 
 **IMPORTANT NOTE** The release name for the enrichment pipeline must be **enrich** (see [Advanced topics](#advanced-topics) for additional information)
+
+
+#### Alternative deployment instructions (insecure)
+
+The instructions listed above are the recommended steps for deploying Health Patterns Enrichment flow. However, it requires sufficient authority to the target cluster to deploy Custom Resource Definitions and configure an OIDC service. If these authorities are not attainable it may be necessary to deploy an unsecured, non-authenticating version of Enrichment.
+
+NOTE: Given the significant differences between the Nifikop-based deployment and this, it is not feasible to maintain both approaches targeting current Nifi dataflows. Therefore, using the insecure deployment will result in a snapshot of these flows current as of November 2021, but not updated since.
+
+First setup deployment parameters:
+
+1) Update your ingress parameters as noted [here](#ingress-parameters).
+
+2) Update values.yaml with the following changes:
+
+nifikop:
+  disabled: &nifikopDisabled true
+  enabled: &nifikopEnabled false
+
+NOTE: Due to a limitation in Helm, when using the Health Patterns chart with a release name other than the defaults of ingestion, you are required to update the values.yaml file to correspond to the correct release name.
+
+`--releaseName=enrich`
+
+Finally, to deploy run:
+
+`helm install enrich. -f clinical_enrichment.yaml`
 
 
 #### Uninstall/delete

--- a/enrich/README.md
+++ b/enrich/README.md
@@ -157,11 +157,6 @@ After running the command above, you will see notes that give you information ab
 **IMPORTANT NOTE** The release name for the enrichment pipeline must be **enrich** (see [Advanced topics](#advanced-topics) for additional information)
 
 
-Finally, to deploy run:
-
-`helm install enrich. -f clinical_enrichment.yaml`
-
-
 #### Uninstall/delete
 
 To uninstall/delete the deployment, use:
@@ -234,27 +229,6 @@ If you would like to turn off that save to FHIR action, you can change the value
 
 ## Advanced topics
 
-#### Synthetic data via Synthea
-
-  If you don't have data, you can create some synthetic clinical data to push. Synthetic patient data can be generated using the Synthea Patient Generator.  Download Synthea and run the following command (for more information on Synthea visit their [Github page](https://github.com/synthetichealth/synthea)):
-
-  `java -jar synthea-with-dependencies.jar -p 10`
-
-  This command will have created FHIR bundles for 10 patients with their clinical history and their corresponding medical providers.
-
-#### Kafka topics for the pipeline
-
-To submit data to the Enrichment pipeline, it needs to be posted to the configured Kafka topic. The Kafka topic to target depends on the pipeline you are running and the Nifi configuration. For example, in the Enrichment pattern the topic is called `patients.updated.out` as was used above.  This can be found and/or updated in the Nifi parameter context `enrichment parameter context` under the parameter `enrich.in`.
-
-The FHIR response with the requested modifications will be placed on a topic called `patient.enriched.out`, again found in the `enrichment parameter context` under the parameter `enrich.out`.
-
-#### Other data formats
-Currently, the enrichment pattern is designed to operate only on data in FHIR format.
-Note that if the enrichment pattern is being used as part of the ingestion pattern, then HL7 data will be
-converted to FHIR (by ingestion) before it is allowed to run through the enrichment pipeline.
-Other data types (such as DICOM image data) are being considered but are currently not supported.
-
-
 #### Alternative deployment instructions (insecure)
 
 The instructions listed above are the recommended steps for deploying Health Patterns Enrichment flow. However, it requires sufficient authority to the target cluster to deploy Custom Resource Definitions and configure an OIDC service. If these authorities are not attainable it may be necessary to deploy an unsecured, non-authenticating version of Enrichment.
@@ -288,6 +262,32 @@ fhir:
     kafka:
       bootstrapServers: "enrich-kafka:9092"
 ```
+
+
+Finally, to deploy run:
+
+`helm install enrich. -f clinical_enrichment.yaml`
+
+
+#### Synthetic data via Synthea
+
+  If you don't have data, you can create some synthetic clinical data to push. Synthetic patient data can be generated using the Synthea Patient Generator.  Download Synthea and run the following command (for more information on Synthea visit their [Github page](https://github.com/synthetichealth/synthea)):
+
+  `java -jar synthea-with-dependencies.jar -p 10`
+
+  This command will have created FHIR bundles for 10 patients with their clinical history and their corresponding medical providers.
+
+#### Kafka topics for the pipeline
+
+To submit data to the Enrichment pipeline, it needs to be posted to the configured Kafka topic. The Kafka topic to target depends on the pipeline you are running and the Nifi configuration. For example, in the Enrichment pattern the topic is called `patients.updated.out` as was used above.  This can be found and/or updated in the Nifi parameter context `enrichment parameter context` under the parameter `enrich.in`.
+
+The FHIR response with the requested modifications will be placed on a topic called `patient.enriched.out`, again found in the `enrichment parameter context` under the parameter `enrich.out`.
+
+#### Other data formats
+Currently, the enrichment pattern is designed to operate only on data in FHIR format.
+Note that if the enrichment pattern is being used as part of the ingestion pattern, then HL7 data will be
+converted to FHIR (by ingestion) before it is allowed to run through the enrichment pipeline.
+Other data types (such as DICOM image data) are being considered but are currently not supported.
 
 
 #### Advanced configuration for Helm Chart

--- a/enrich/README.md
+++ b/enrich/README.md
@@ -168,13 +168,28 @@ First setup deployment parameters:
 
 2) Update values.yaml with the following changes:
 
+```
 nifikop:
   disabled: &nifikopDisabled true
   enabled: &nifikopEnabled false
+```
 
-NOTE: Due to a limitation in Helm, when using the Health Patterns chart with a release name other than the defaults of ingestion, you are required to update the values.yaml file to correspond to the correct release name.
+NOTE: Due to a limitation in Helm, when using the Health Patterns chart with a release name other than the defaults of `enrich`, you are required to update the clinical_enrichment.yaml file to correspond to the correct release name and bootstrapServers.
 
-`--releaseName=enrich`
+```
+nifi:
+  extraContainers:
+    - name: post-start-setup
+      env:
+      - name: "RELEASE_NAME"
+        value: "enrich"
+
+fhir:
+  notifications:
+    kafka:
+      bootstrapServers: "enrich-kafka:9092"
+```
+
 
 Finally, to deploy run:
 

--- a/helm-charts/health-patterns/README_Helm.md
+++ b/helm-charts/health-patterns/README_Helm.md
@@ -122,19 +122,12 @@ nifi2:
 The following Helm command will deploy the ingestion pattern.  The entire pipeline will be ready to normalize, validate, enrich, and finally persist FHIR data to a FHIR server.
 
 ```
-helm install ingestion .
+helm install <<RELEASE_NAME>> .
 ```
 
 After running the command above, you will see notes that give you information about the deployment, in particular, where the important services (e.g. FHIR, Nifi, expose-kafka) have been deployed.
 
 **IMPORTANT NOTE** The release name for the ingestion pipeline must be **ingestion** (see [Advanced topics](#advanced-topics) for additional information)
-
-
-3) When deploying the helm chart, you will need to supply the variation.yaml (ingestion/enrichment) indicating which you wish to deploy:
-
-`helm install ingestion . -f clinical_ingestion.yaml`
-or
-`helm install enrich . -f clinical_enrichment.yaml`
 
 
 #### Uninstall/delete
@@ -206,6 +199,12 @@ fhir:
     kafka:
       bootstrapServers: "enrich-kafka:9092"
 ```
+
+3) When deploying the helm chart, you will need to supply the variation.yaml (ingestion/enrichment) indicating which you wish to deploy:
+
+`helm install ingestion . -f clinical_ingestion.yaml`
+or
+`helm install enrich . -f clinical_enrichment.yaml`
 
 
 ### Optional: Deploy a FHIR UI

--- a/helm-charts/health-patterns/README_Helm.md
+++ b/helm-charts/health-patterns/README_Helm.md
@@ -16,11 +16,9 @@ Alvearie Health Patterns is comprised of multiple components described in more d
 
 ## Installation
 
-### Checkout the Code
+#### Checkout the Code
 
-Alternatively, you can clone this Git repository deploy the chart from the source:
-
-```bash
+```
 git clone https://github.com/Alvearie/health-patterns.git
 cd health-patterns/helm-charts/health-patterns
 helm dependency update
@@ -28,7 +26,7 @@ helm dependency update
 
 Note: by changing the directory as shown above, you will be in the right place for future file access.
 
-### Create a new namespace (Optional)
+#### Create a new namespace
 
 Please note that although this is step is optional, it is highly recommended that you create a new namespace in your Kubernetes cluster before installing the pattern.  This will help prevent the various artifacts it will install from mixing with other artifacts that might already be present in your Kubernetes cluster.  To create a new namespace called ```alvearie``` and make it your default for future commands:
 
@@ -38,7 +36,6 @@ kubectl config set-context --current --namespace=alvearie
 ```
 
 **NOTE:** The length of a namespace name must be less than or equal to **20 characters**.  Using a name that is longer than 20 characters will result in a failure to deploy the Nifi pod due to a certificate issue (the error will be visible in the NifiKop log).
-
 
 ### Configure Nifikop
 
@@ -55,14 +52,14 @@ helm repo update
 
 helm install nifikop \
     orange-incubator/nifikop \
-    --namespace=<<NAMESPACE>> \
+    --namespace=alvearie \
     --version 0.7.1 \
     --set image.tag=v0.7.1-release \
     --set resources.requests.memory=256Mi \
     --set resources.requests.cpu=250m \
     --set resources.limits.memory=256Mi \
     --set resources.limits.cpu=250m \
-    --set namespaces={"<<NAMESPACE>>"}
+    --set namespaces={"alvearie"}
 ```
 
 ### User Authentication - OpenID Connect
@@ -81,7 +78,7 @@ oidc:
     secret - The client secret of your OIDC discovery service
 ```
 
-**NOTE:** You will also need to register your OIDC callback (`https://<<HOST_NAME>>:443/nifi-api/access/oidc/callback`) with your OIDC service.  For IBM App ID, this is located under Manage Authentication->Authentication Settings->Add Web Redirect URLs.
+**NOTE:** You will also need to register your OIDC callback (`https://<<external-hostname>>:443/nifi-api/access/oidc/callback`) with your OIDC service.  For IBM App ID, this is located under Manage Authentication->Authentication Settings->Add Web Redirect URLs.
 
 #### Ingress parameters
 
@@ -123,23 +120,25 @@ nifi2:
 
 #### Deployment
 The following Helm command will deploy the ingestion pattern.  The entire pipeline will be ready to normalize, validate, enrich, and finally persist FHIR data to a FHIR server.
+
 ```
 helm install ingestion .
 ```
+
 After running the command above, you will see notes that give you information about the deployment, in particular, where the important services (e.g. FHIR, Nifi, expose-kafka) have been deployed.
 
 **IMPORTANT NOTE** The release name for the ingestion pipeline must be **ingestion** (see [Advanced topics](#advanced-topics) for additional information)
 
 
-### Alternative deployment instructions (insecure)
+#### Alternative deployment instructions (insecure)
 
 The instructions listed above are the recommended steps for deploying Health Patterns Ingestion/Enrichment flows.  However, it requires sufficient authority to the target cluster to deploy Custom Resource Definitions and configure an OIDC service.  If these authorities are not attainable it may be necessary to deploy an unsecured, non-authenticating version of Ingestion or Enrichment.  
 
-**NOTE:** Given the significant differences between the Nifikop-based deployment and this, it is not feasible to maintain both approaches targeting current Nifi dataflows.  Therefore, using the insecure deployment will result in a snapshot of these flows current as of November 2021, but not updated since.
+**NOTE:** Given the significant differences between the Nifikop-based deployment and this, it is not feasible to maintain both approaches targeting current Nifi dataflows. Therefore, using the insecure deployment will result in a snapshot of these flows current as of November 2021, but not updated since.
 
-To deploy:
+First, setup deployment parameters:
 
-1) Update your ingress parameters as noted [here](README_Helm.md#ingress-parameters).
+1) Update your ingress parameters as noted [here](#ingress-parameters).
 
 2) Update values.yaml with the following changes:
 
@@ -149,30 +148,65 @@ nifikop:
   enabled: &nifikopEnabled false
 ```
 
-3) When deploying the helm chart, you will need to supply the variation.yaml (ingestion/enrichment) indicating which you wish to deploy:
-
-`helm install <<RELEASE_NAME>> . -f clinical_ingestion.yaml`
-or
-`helm install <<RELEASE_NAME>> . -f clinical_enrichment.yaml`
-
-
 **NOTE:** Due to a limitation in Helm, when using the Health Patterns chart with a release name other than the defaults of `ingestion` and `enrich`, you are required to update the corresponding values.yaml file to correspond to the correct release name.  
 
 For Clinical Ingestion, update:
--- the line `--releaseName=ingest` to include the correct Helm release name.
+
+```
+nifi:
+  extraContainers:
+    - name: post-start-setup
+      env:
+      - name: "RELEASE_NAME"
+        value: "ingest"
+```
 
 For Clinical Enrichment, update:
-- the line `--releaseName=enrich` to include the correct Helm release name.
-- the line `bootstrapServers: "enrich-kafka:9092"` to include the correct Kafka broker, including the release name.
+
+```
+nifi:
+  extraContainers:
+    - name: post-start-setup
+      env:
+      - name: "RELEASE_NAME"
+        value: "enrich"
+
+fhir:
+  notifications:
+    kafka:
+      bootstrapServers: "enrich-kafka:9092"
+```
 
 
+3) When deploying the helm chart, you will need to supply the variation.yaml (ingestion/enrichment) indicating which you wish to deploy:
 
-## Using the Chart
+`helm install ingestion . -f clinical_ingestion.yaml`
+or
+`helm install enrich . -f clinical_enrichment.yaml`
+
+
+#### Uninstall/delete
+
+To uninstall/delete the <<RELEASE_NAME>> deployment, use:
+
+```
+helm delete <<RELEASE_NAME>>
+```
+
+Deletion of charts doesn't cascade to deleting associated `PersistedVolume`s and `PersistedVolumeClaims`s.
+To delete them:
+
+```bash
+kubectl delete pvc -l release=ingestion
+kubectl delete pv -l release=ingestion
+```
+
+## Using the pattern
 
 After running the previous `helm install` command, you should get a set of instructions on how to access the various components of the chart and using the [Alvearie Clinical Ingestion pattern](../../README.md).
 
 
-## Optional: Deploy a FHIR UI
+### Optional: Deploy a FHIR UI
 
 Follow the instructions for deploying the [Alvearie Patient Browser App](https://github.com/Alvearie/patient-browser/tree/master/chart#installation) if you need a FHIR UI.
 
@@ -186,22 +220,6 @@ and
 
 ```
 --set fhir-deid.proxy.enabled=true
-```
-
-## Uninstallation
-
-To uninstall/delete the `ingestion` deployment:
-
-```bash
-helm delete ingestion
-```
-
-Deletion of charts doesn't cascade to deleting associated `PersistedVolume`s and `PersistedVolumeClaims`s.
-To delete them:
-
-```bash
-kubectl delete pvc -l release=ingestion
-kubectl delete pv -l release=ingestion
 ```
 
 ## Configuration

--- a/helm-charts/health-patterns/README_Helm.md
+++ b/helm-charts/health-patterns/README_Helm.md
@@ -16,7 +16,7 @@ Alvearie Health Patterns is comprised of multiple components described in more d
 
 ## Installation
 
-### Create a new namespace (Optional)
+## Create a new namespace (Optional)
 
 It is recommended, though not required, that you create a namespace before installing the chart in order to prevent the various artifacts that will be installed by it from mixing from the rest of the artifacts in your Kubernetes cluster, in an effort to make it easier to manage them.
 
@@ -27,7 +27,7 @@ kubectl config set-context --current --namespace=alvearie
 **NOTE:** The length of a namespace name must be less than or equal to **20 characters**.  Using a name that is longer than 20 characters will result in a failure to deploy the Nifi pod due to a certificate issue (the error will be visible in the NifiKop log).
 
 
-### Checkout the Code
+## Checkout the Code
 
 Alternatively, you can clone this Git repository deploy the chart from the source:
 
@@ -37,7 +37,7 @@ cd health-patterns/helm-charts/health-patterns
 helm dependency update
 ```
 
-### Configure Nifikop
+## Configure Nifikop
 
 This chart relies on [NifiKop](https://orange-opensource.github.io/nifikop/) to deploy Apache Nifi.  This relies on a one-time setup for your cluster to install the Custom Resource Definitions properly.  See [Getting Started](https://orange-opensource.github.io/nifikop/docs/2_setup/1_getting_started) for instructions on how to setup your cluster.
 
@@ -80,9 +80,7 @@ oidc:
 
 **NOTE:** You will also need to register your OIDC callback (`https://<<HOST_NAME>>:443/nifi-api/access/oidc/callback`) with your OIDC service.  For IBM App ID, this is located under Manage Authentication->Authentication Settings->Add Web Redirect URLs.
 
-## Required parameters
-
-### Ingress parameters
+## Ingress parameters
 
 We recommend exposing the services in this chart via ingress.  This provides the most robust and secure approach.  If you choose to expose services via port-forwarding, load-balancer, or other options, please be careful to ensure proper security.
 
@@ -95,7 +93,7 @@ ingress:
 
 This value should be updated in the values file you use to deploy your pipeline.
 
-### Storage class
+## Storage class
 And finally, if you are deploying to a non-IBM cloud, you will need to change the storage class used by Nifi by updating the following parameter:
 
 ```
@@ -104,7 +102,7 @@ nifi2:
 ```
 
 
-### Ingestion vs Enrichment
+## Ingestion vs Enrichment
 
 There are two variations of the health-patterns Helm chart currently supported:
 - Clinical Ingestion - This variation will deploy an entire pipeline ready to normalize, validate, enrich, and persist FHIR data to a FHIR server.  This variation typically involves a RELEASE_NAME of `ingestion` and requires `ingestion.enabled` and `enrichment.enabled` to be set to `true`.
@@ -113,14 +111,14 @@ There are two variations of the health-patterns Helm chart currently supported:
 **NOTE:** These parameters cannot be set via helm install command parameters via "--set" as the variables will not be de-referenced in the proper order to propagate to later uses of this parameter.  Instead, update the values.yaml with your preference.
 
 
-### Deploy
+# Deploy
 
 Finally, to deploy this chart, run:
 
 `helm install <<RELEASE_NAME>> .`
 
 
-### Alternative deployment instructions (insecure)
+## Alternative deployment instructions (insecure)
 
 The instructions listed above are the recommended steps for deploying Health Patterns Ingestion/Enrichment flows.  However, it requires sufficient authority to the target cluster to deploy Custom Resource Definitions and configure an OIDC service.  If these authorities are not attainable it may be necessary to deploy an unsecured, non-authenticating version of Ingestion or Enrichment.  
 
@@ -134,8 +132,8 @@ To deploy:
 
 ```
 nifikop:
-  disabled: &nifikopDisabled **true**
-  enabled: &nifikopEnabled **false**
+  disabled: &nifikopDisabled true
+  enabled: &nifikopEnabled false
 ```
 
 3) When deploying the helm chart, you will need to supply the variation.yaml (ingestion/enrichment) indicating which you wish to deploy:
@@ -156,12 +154,12 @@ For Clinical Enrichment, update:
 
 
 
-### Using the Chart
+## Using the Chart
 
 After running the previous `helm install` command, you should get a set of instructions on how to access the various components of the chart and using the [Alvearie Clinical Ingestion pattern](../../README.md).
 
 
-### Optional: Deploy a FHIR UI
+## Optional: Deploy a FHIR UI
 
 Follow the instructions for deploying the [Alvearie Patient Browser App](https://github.com/Alvearie/patient-browser/tree/master/chart#installation) if you need a FHIR UI.
 

--- a/helm-charts/health-patterns/README_Helm.md
+++ b/helm-charts/health-patterns/README_Helm.md
@@ -16,7 +16,7 @@ Alvearie Health Patterns is comprised of multiple components described in more d
 
 ## Installation
 
-## Create a new namespace (Optional)
+### Create a new namespace (Optional)
 
 It is recommended, though not required, that you create a namespace before installing the chart in order to prevent the various artifacts that will be installed by it from mixing from the rest of the artifacts in your Kubernetes cluster, in an effort to make it easier to manage them.
 
@@ -27,7 +27,7 @@ kubectl config set-context --current --namespace=alvearie
 **NOTE:** The length of a namespace name must be less than or equal to **20 characters**.  Using a name that is longer than 20 characters will result in a failure to deploy the Nifi pod due to a certificate issue (the error will be visible in the NifiKop log).
 
 
-## Checkout the Code
+### Checkout the Code
 
 Alternatively, you can clone this Git repository deploy the chart from the source:
 
@@ -37,7 +37,7 @@ cd health-patterns/helm-charts/health-patterns
 helm dependency update
 ```
 
-## Configure Nifikop
+### Configure Nifikop
 
 This chart relies on [NifiKop](https://orange-opensource.github.io/nifikop/) to deploy Apache Nifi.  This relies on a one-time setup for your cluster to install the Custom Resource Definitions properly.  See [Getting Started](https://orange-opensource.github.io/nifikop/docs/2_setup/1_getting_started) for instructions on how to setup your cluster.
 
@@ -80,7 +80,7 @@ oidc:
 
 **NOTE:** You will also need to register your OIDC callback (`https://<<HOST_NAME>>:443/nifi-api/access/oidc/callback`) with your OIDC service.  For IBM App ID, this is located under Manage Authentication->Authentication Settings->Add Web Redirect URLs.
 
-## Ingress parameters
+### Ingress parameters
 
 We recommend exposing the services in this chart via ingress.  This provides the most robust and secure approach.  If you choose to expose services via port-forwarding, load-balancer, or other options, please be careful to ensure proper security.
 
@@ -93,7 +93,7 @@ ingress:
 
 This value should be updated in the values file you use to deploy your pipeline.
 
-## Storage class
+### Storage class
 And finally, if you are deploying to a non-IBM cloud, you will need to change the storage class used by Nifi by updating the following parameter:
 
 ```
@@ -102,7 +102,7 @@ nifi2:
 ```
 
 
-## Ingestion vs Enrichment
+### Ingestion vs Enrichment
 
 There are two variations of the health-patterns Helm chart currently supported:
 - Clinical Ingestion - This variation will deploy an entire pipeline ready to normalize, validate, enrich, and persist FHIR data to a FHIR server.  This variation typically involves a RELEASE_NAME of `ingestion` and requires `ingestion.enabled` and `enrichment.enabled` to be set to `true`.
@@ -111,14 +111,14 @@ There are two variations of the health-patterns Helm chart currently supported:
 **NOTE:** These parameters cannot be set via helm install command parameters via "--set" as the variables will not be de-referenced in the proper order to propagate to later uses of this parameter.  Instead, update the values.yaml with your preference.
 
 
-# Deploy
+## Deploy
 
 Finally, to deploy this chart, run:
 
 `helm install <<RELEASE_NAME>> .`
 
 
-## Alternative deployment instructions (insecure)
+### Alternative deployment instructions (insecure)
 
 The instructions listed above are the recommended steps for deploying Health Patterns Ingestion/Enrichment flows.  However, it requires sufficient authority to the target cluster to deploy Custom Resource Definitions and configure an OIDC service.  If these authorities are not attainable it may be necessary to deploy an unsecured, non-authenticating version of Ingestion or Enrichment.  
 

--- a/helm-charts/health-patterns/README_Helm.md
+++ b/helm-charts/health-patterns/README_Helm.md
@@ -130,6 +130,36 @@ After running the command above, you will see notes that give you information ab
 **IMPORTANT NOTE** The release name for the ingestion pipeline must be **ingestion** (see [Advanced topics](#advanced-topics) for additional information)
 
 
+3) When deploying the helm chart, you will need to supply the variation.yaml (ingestion/enrichment) indicating which you wish to deploy:
+
+`helm install ingestion . -f clinical_ingestion.yaml`
+or
+`helm install enrich . -f clinical_enrichment.yaml`
+
+
+#### Uninstall/delete
+
+To uninstall/delete the <<RELEASE_NAME>> deployment, use:
+
+```
+helm delete <<RELEASE_NAME>>
+```
+
+Deletion of charts doesn't cascade to deleting associated `PersistedVolume`s and `PersistedVolumeClaims`s.
+To delete them:
+
+```bash
+kubectl delete pvc -l release=ingestion
+kubectl delete pv -l release=ingestion
+```
+
+## Using the pattern
+
+After running the previous `helm install` command, you should get a set of instructions on how to access the various components of the chart and using the [Alvearie Clinical Ingestion pattern](../../README.md).
+
+## Advanced topics
+
+
 #### Alternative deployment instructions (insecure)
 
 The instructions listed above are the recommended steps for deploying Health Patterns Ingestion/Enrichment flows.  However, it requires sufficient authority to the target cluster to deploy Custom Resource Definitions and configure an OIDC service.  If these authorities are not attainable it may be necessary to deploy an unsecured, non-authenticating version of Ingestion or Enrichment.  
@@ -176,34 +206,6 @@ fhir:
     kafka:
       bootstrapServers: "enrich-kafka:9092"
 ```
-
-
-3) When deploying the helm chart, you will need to supply the variation.yaml (ingestion/enrichment) indicating which you wish to deploy:
-
-`helm install ingestion . -f clinical_ingestion.yaml`
-or
-`helm install enrich . -f clinical_enrichment.yaml`
-
-
-#### Uninstall/delete
-
-To uninstall/delete the <<RELEASE_NAME>> deployment, use:
-
-```
-helm delete <<RELEASE_NAME>>
-```
-
-Deletion of charts doesn't cascade to deleting associated `PersistedVolume`s and `PersistedVolumeClaims`s.
-To delete them:
-
-```bash
-kubectl delete pvc -l release=ingestion
-kubectl delete pv -l release=ingestion
-```
-
-## Using the pattern
-
-After running the previous `helm install` command, you should get a set of instructions on how to access the various components of the chart and using the [Alvearie Clinical Ingestion pattern](../../README.md).
 
 
 ### Optional: Deploy a FHIR UI

--- a/helm-charts/health-patterns/templates/nifi-cluster.yaml
+++ b/helm-charts/health-patterns/templates/nifi-cluster.yaml
@@ -37,8 +37,6 @@ spec:
         nifi.security.user.oidc.client.id={{ .Values.nifi2.oidc.client.id }}
         nifi.security.user.oidc.client.secret={{ .Values.nifi2.oidc.client.secret }}
         nifi.security.user.oidc.preferred.jwsalgorithm=RS256
-{{ else }}
-        nifi.security.user.login.identity.provider=single-user-provider
 {{- end }}
       webProxyHosts:
         - {{ .Values.nifi2.ingress.hostname }}

--- a/helm-charts/health-patterns/templates/nifi-cluster.yaml
+++ b/helm-charts/health-patterns/templates/nifi-cluster.yaml
@@ -12,10 +12,12 @@ spec:
   zkPath: "/nifi"
   clusterImage: {{ .Values.nifi2.image.repository }}:{{ .Values.nifi2.image.tag }}
   oneNifiNodePerNode: false
+{{- if .Values.nifi2.user }}
   managedAdminUsers:
 {{- range $u := .Values.nifi2.user }}
   - identity: {{ $u.identity }}
     name: {{ $u.name }}
+{{- end }}
 {{- end }}
   propagateLabels: true
   nifiClusterTaskSpec:
@@ -23,17 +25,21 @@ spec:
   readOnlyConfig:
     # NifiProperties configuration that will be applied to the node.
     nifiProperties:
-      # Additionnals nifi.properties configuration that will override the one produced based
+      # Additional nifi.properties configuration that will override the one produced based
       # on template and configurations.
       overrideConfigs: |
         nifi.security.identity.mapping.pattern.dn=CN=([^,]*)(?:, (?:O|OU)=.*)?
         nifi.security.identity.mapping.transform.dn=NONE
         nifi.security.identity.mapping.value.dn=$1
+        nifi.nar.library.autoload.directory=/opt/nifi/extensions
+{{- if .Values.nifi2.oidc }}
         nifi.security.user.oidc.discovery.url={{ .Values.nifi2.oidc.discovery.url }}
         nifi.security.user.oidc.client.id={{ .Values.nifi2.oidc.client.id }}
         nifi.security.user.oidc.client.secret={{ .Values.nifi2.oidc.client.secret }}
         nifi.security.user.oidc.preferred.jwsalgorithm=RS256
-        nifi.nar.library.autoload.directory=/opt/nifi/extensions
+{{ else }}
+        nifi.security.user.login.identity.provider=single-user-provider
+{{- end }}
       webProxyHosts:
         - {{ .Values.nifi2.ingress.hostname }}
   nodeConfigGroups:
@@ -116,18 +122,20 @@ spec:
       nodeConfigGroup: "default_group"
   listenersConfig:
     internalListeners:
-      - type: "https"
-        name: "https"
-        containerPort: {{ .Values.nifi2.service.port}}
+      - type: "{{ .Values.nifi2.service.protocol }}"
+        name: "{{ .Values.nifi2.service.protocol }}"
+        containerPort: {{ .Values.nifi2.service.port }}
       - type: "cluster"
         name: "cluster"
         containerPort: 6007
       - type: "s2s"
         name: "s2s"
         containerPort: 10000
+{{- if eq $.Values.nifi2.service.protocol "https" }}
     sslSecrets:
       tlsSecretName: {{ .Release.Namespace }}-nifikop
       create: true
+{{- end }}
   initContainers:
     # This init container will install the custom NiFi Processors (packed in the proper NAR format).
     # The NARs will be copied to a shared volume, and the customLibPath will be set to the location

--- a/helm-charts/health-patterns/values.yaml
+++ b/helm-charts/health-patterns/values.yaml
@@ -52,8 +52,8 @@ oidc:
     secret: &oidc_client_secret replace-me
 
 nifikop:
-  disabled: &nifikopDisabled true
-  enabled: &nifikopEnabled false
+  disabled: &nifikopDisabled false
+  enabled: &nifikopEnabled true
 
 ascvd:
   enabled: true
@@ -293,6 +293,7 @@ nifi2: # NifiKop based Nifi
     class: *ingressClass
     hostname: *hostname
   service:
+    protocol: https
     port: 8443
   storageClassName: ibmc-vpc-block-metro-10iops-tier
   dataflow:

--- a/ingest/README.md
+++ b/ingest/README.md
@@ -168,13 +168,22 @@ First setup deployment parameters:
 
 2) Update values.yaml with the following changes:
 
+```
 nifikop:
   disabled: &nifikopDisabled true
   enabled: &nifikopEnabled false
+```
 
-NOTE: Due to a limitation in Helm, when using the Health Patterns chart with a release name other than the defaults of ingestion, you are required to update the values.yaml file to correspond to the correct release name.
+NOTE: Due to a limitation in Helm, when using the Health Patterns chart with a release name other than the defaults of `ingestion`, you are required to update the clinical_ingestion.yaml file to correspond to the correct release name.
 
-`--releaseName=ingest`
+```
+nifi:
+  extraContainers:
+    - name: post-start-setup
+      env:
+      - name: "RELEASE_NAME"
+        value: "ingest"
+```
 
 Finally, to deploy run:
 

--- a/ingest/README.md
+++ b/ingest/README.md
@@ -228,11 +228,6 @@ nifikop:
   enabled: &nifikopEnabled false
 ```
 
-Finally, to deploy run:
-
-`helm install ingestion . -f clinical_ingestion.yaml`
-
-
 **NOTE:** Due to a limitation in Helm, when using the Health Patterns chart with a release name other than the defaults of `ingestion`, you are required to update the clinical_ingestion.yaml file to correspond to the correct release name.
 
 ```
@@ -243,6 +238,10 @@ nifi:
       - name: "RELEASE_NAME"
         value: "ingest"
 ```
+
+Finally, to deploy run:
+
+`helm install ingestion . -f clinical_ingestion.yaml`
 
 
 #### FHIR Server configuration

--- a/ingest/README.md
+++ b/ingest/README.md
@@ -156,11 +156,6 @@ After running the command above, you will see notes that give you information ab
 **IMPORTANT NOTE** The release name for the ingestion pipeline must be **ingestion** (see [Advanced topics](#advanced-topics) for additional information)
 
 
-Finally, to deploy run:
-
-`helm install ingestion . -f clinical_ingestion.yaml`
-
-
 #### Uninstall/delete
 
 To uninstall/delete the deployment, use:
@@ -232,6 +227,11 @@ nifikop:
   disabled: &nifikopDisabled true
   enabled: &nifikopEnabled false
 ```
+
+Finally, to deploy run:
+
+`helm install ingestion . -f clinical_ingestion.yaml`
+
 
 **NOTE:** Due to a limitation in Helm, when using the Health Patterns chart with a release name other than the defaults of `ingestion`, you are required to update the clinical_ingestion.yaml file to correspond to the correct release name.
 

--- a/ingest/README.md
+++ b/ingest/README.md
@@ -78,14 +78,14 @@ helm repo update
 
 helm install nifikop \
     orange-incubator/nifikop \
-    --namespace=<<NAMESPACE>> \
+    --namespace=alvearie \
     --version 0.7.1 \
     --set image.tag=v0.7.1-release \
     --set resources.requests.memory=256Mi \
     --set resources.requests.cpu=250m \
     --set resources.limits.memory=256Mi \
     --set resources.limits.cpu=250m \
-    --set namespaces={"<<NAMESPACE>>"}
+    --set namespaces={"alvearie"}
 ```
 
 ### User Authentication - OpenID Connect
@@ -104,7 +104,7 @@ oidc:
     secret - The client secret of your OIDC discovery service
 ```
 
-**NOTE:** You will also need to register your OIDC callback (`https://<<HOST_NAME>>:443/nifi-api/access/oidc/callback`) with your OIDC service.  For IBM App ID, this is located under Manage Authentication->Authentication Settings->Add Web Redirect URLs.
+**NOTE:** You will also need to register your OIDC callback (`https://<<external-hostname>>:443/nifi-api/access/oidc/callback`) with your OIDC service.  For IBM App ID, this is located under Manage Authentication->Authentication Settings->Add Web Redirect URLs.
 
 #### Ingress parameters
 
@@ -160,9 +160,9 @@ After running the command above, you will see notes that give you information ab
 
 The instructions listed above are the recommended steps for deploying Health Patterns Ingestion flow. However, it requires sufficient authority to the target cluster to deploy Custom Resource Definitions and configure an OIDC service. If these authorities are not attainable it may be necessary to deploy an unsecured, non-authenticating version of Ingestion.
 
-NOTE: Given the significant differences between the Nifikop-based deployment and this, it is not feasible to maintain both approaches targeting current Nifi dataflows. Therefore, using the insecure deployment will result in a snapshot of these flows current as of November 2021, but not updated since.
+**NOTE:** Given the significant differences between the Nifikop-based deployment and this, it is not feasible to maintain both approaches targeting current Nifi dataflows. Therefore, using the insecure deployment will result in a snapshot of these flows current as of November 2021, but not updated since.
 
-First setup deployment parameters:
+First, setup deployment parameters:
 
 1) Update your ingress parameters as noted [here](#ingress-parameters).
 
@@ -174,7 +174,7 @@ nifikop:
   enabled: &nifikopEnabled false
 ```
 
-NOTE: Due to a limitation in Helm, when using the Health Patterns chart with a release name other than the defaults of `ingestion`, you are required to update the clinical_ingestion.yaml file to correspond to the correct release name.
+**NOTE:** Due to a limitation in Helm, when using the Health Patterns chart with a release name other than the defaults of `ingestion`, you are required to update the clinical_ingestion.yaml file to correspond to the correct release name.
 
 ```
 nifi:
@@ -193,8 +193,17 @@ Finally, to deploy run:
 #### Uninstall/delete
 
 To uninstall/delete the deployment, use:
+
 ```
 helm delete ingestion
+```
+
+Deletion of charts doesn't cascade to deleting associated `PersistedVolume`s and `PersistedVolumeClaims`s.
+To delete them:
+
+```bash
+kubectl delete pvc -l release=ingestion
+kubectl delete pv -l release=ingestion
 ```
 
 ## Using the pattern
@@ -245,7 +254,7 @@ This pattern relies on a FHIR server for data persistence and retrieval.  It pro
 
   This command will have created FHIR bundles for 10 patients with their clinical history and their corresponding medical providers.
 
-### Deploy a FHIR UI
+### Optional: Deploy a FHIR UI
 
 Follow the instructions for deploying the [Alvearie Patient Browser App](https://github.com/Alvearie/patient-browser/tree/master/chart#installation) if you need a FHIR UI.
 

--- a/ingest/README.md
+++ b/ingest/README.md
@@ -31,12 +31,16 @@ Within the [NiFi](https://github.com/apache/nifi) canvas, the Ingestion health p
 ## How to deploy
 
 #### Prerequisites
+
 These instructions assume that you have the following resources, tools, and configurations:
 
 - Kubernetes cluster 1.10+
 - Helm 3.0.0+
 - Access to ```kubectl```, the Kubernetes command line tool
 - PV provisioner support in the underlying infrastructure
+
+**Note:** If you don't have access to a kubernetes cluster, this pattern can also be [deployed to minikube](../helm-charts/health-patterns/README_minikube.md).
+
 
 #### Check out the code
 
@@ -57,6 +61,51 @@ kubectl create namespace alvearie
 kubectl config set-context --current --namespace=alvearie
 ```
 
+**NOTE:** The length of a namespace name must be less than or equal to **20 characters**.  Using a name that is longer than 20 characters will result in a failure to deploy the Nifi pod due to a certificate issue (the error will be visible in the NifiKop log).
+
+### Configure Nifikop
+
+This chart relies on [NifiKop](https://orange-opensource.github.io/nifikop/) to deploy Apache Nifi.  This relies on a one-time setup for your cluster to install the Custom Resource Definitions properly.  See [Getting Started](https://orange-opensource.github.io/nifikop/docs/2_setup/1_getting_started) for instructions on how to setup your cluster.
+
+In addition, using NifiKop requires a NifiKop controller to be deployed in the namespace prior to deploying the Health Patterns Helm chart.  This allows the NifiKop custom resources to be managed correctly, and by deploying separately guarantees the controller remains active when custom resources are deleted, allowing proper clean-up.
+
+To deploy a NifiKop controller to your namespace, run:
+
+```
+helm repo add orange-incubator https://orange-kubernetes-charts-incubator.storage.googleapis.com/
+
+helm repo update
+
+helm install nifikop \
+    orange-incubator/nifikop \
+    --namespace=<<NAMESPACE>> \
+    --version 0.7.1 \
+    --set image.tag=v0.7.1-release \
+    --set resources.requests.memory=256Mi \
+    --set resources.requests.cpu=250m \
+    --set resources.limits.memory=256Mi \
+    --set resources.limits.cpu=250m \
+    --set namespaces={"<<NAMESPACE>>"}
+```
+
+### User Authentication - OpenID Connect
+
+Nifikop configures a secure Nifi instance which relies on [OIDC](https://openid.net/connect/) to authenticate user access.  This requires you to separately setup an OIDC service and supply the correct configuration information to this Helm chart.  For example, [App Id](https://www.ibm.com/cloud/app-id) is available for IBM Cloud instances.
+
+Once configured, update the values.yaml to populate the following parameters.
+
+```
+oidc:
+  users - a list of identity/name values representing the user(s) you want configured for access.  The identity must match the login identity from your OIDC endpoint, and the name should be lower-case and contain no spaces.
+  discovery:
+    url - The URL of your OIDC discovery service
+  client:
+    id - The client ID of your OIDC discovery service
+    secret - The client secret of your OIDC discovery service
+```
+
+**NOTE:** You will also need to register your OIDC callback (`https://<<HOST_NAME>>:443/nifi-api/access/oidc/callback`) with your OIDC service.  For IBM App ID, this is located under Manage Authentication->Authentication Settings->Add Web Redirect URLs.
+
 #### Ingress parameters
 
 We recommend exposing the services in this chart via ingress.  This provides the most robust and secure approach.  If you choose to expose services via port-forwarding, load-balancer, or other options, please be careful to ensure proper security.
@@ -68,7 +117,7 @@ Ingress requires a specific ingress class to be used.  Different cloud providers
 
 You will also need to provide a hostname for your ingress.  What this is and how it gets created will be unique to your cloud infrastructure.  
 
-Once you know these values, use both of them to update the `ingress` section of the file ```helm-charts/health-patterns/values.yaml```  as shown below.  Note that the ingress class currently defaults to `public-iks-k8s-nginx` so if that is your choice, no update to the ingress class is needed.  However, the ingress hostname **MUST** be updated.
+Once you know these values, use both of them to update the `ingress` section of the file ```helm-charts/health-patterns/values.yaml```  as shown below. Note that the ingress class currently defaults to `public-iks-k8s-nginx` so if that is your choice, no update to the ingress class is needed.  However, the ingress hostname **MUST** be updated.
 
 ```
 ingress:
@@ -87,14 +136,50 @@ ingress:
 ```
 
 
+### Storage class
+And finally, if you are deploying to a non-IBM cloud, you will need to change the storage class used by Nifi by updating the following parameter:
+
+```
+nifi2:
+  storageClassName - The storage class you wish to use for persisting Nifi.
+```
+
 #### Deployment
 The following Helm command will deploy the ingestion pattern.  The entire pipeline will be ready to normalize, validate, enrich, and finally persist FHIR data to a FHIR server.
+
 ```
-helm install ingestion .  -f clinical_ingestion.yaml
+helm install ingestion .
 ```
+
 After running the command above, you will see notes that give you information about the deployment, in particular, where the important services (e.g. FHIR, Nifi, expose-kafka) have been deployed.
 
 **IMPORTANT NOTE** The release name for the ingestion pipeline must be **ingestion** (see [Advanced topics](#advanced-topics) for additional information)
+
+
+#### Alternative deployment instructions (insecure)
+
+The instructions listed above are the recommended steps for deploying Health Patterns Ingestion flow. However, it requires sufficient authority to the target cluster to deploy Custom Resource Definitions and configure an OIDC service. If these authorities are not attainable it may be necessary to deploy an unsecured, non-authenticating version of Ingestion.
+
+NOTE: Given the significant differences between the Nifikop-based deployment and this, it is not feasible to maintain both approaches targeting current Nifi dataflows. Therefore, using the insecure deployment will result in a snapshot of these flows current as of November 2021, but not updated since.
+
+First setup deployment parameters:
+
+1) Update your ingress parameters as noted [here](#ingress-parameters).
+
+2) Update values.yaml with the following changes:
+
+nifikop:
+  disabled: &nifikopDisabled true
+  enabled: &nifikopEnabled false
+
+NOTE: Due to a limitation in Helm, when using the Health Patterns chart with a release name other than the defaults of ingestion, you are required to update the values.yaml file to correspond to the correct release name.
+
+`--releaseName=ingest`
+
+Finally, to deploy run:
+
+`helm install ingestion . -f clinical_ingestion.yaml`
+
 
 #### Uninstall/delete
 
@@ -102,7 +187,6 @@ To uninstall/delete the deployment, use:
 ```
 helm delete ingestion
 ```
-
 
 ## Using the pattern
 

--- a/ingest/README.md
+++ b/ingest/README.md
@@ -156,35 +156,6 @@ After running the command above, you will see notes that give you information ab
 **IMPORTANT NOTE** The release name for the ingestion pipeline must be **ingestion** (see [Advanced topics](#advanced-topics) for additional information)
 
 
-#### Alternative deployment instructions (insecure)
-
-The instructions listed above are the recommended steps for deploying Health Patterns Ingestion flow. However, it requires sufficient authority to the target cluster to deploy Custom Resource Definitions and configure an OIDC service. If these authorities are not attainable it may be necessary to deploy an unsecured, non-authenticating version of Ingestion.
-
-**NOTE:** Given the significant differences between the Nifikop-based deployment and this, it is not feasible to maintain both approaches targeting current Nifi dataflows. Therefore, using the insecure deployment will result in a snapshot of these flows current as of November 2021, but not updated since.
-
-First, setup deployment parameters:
-
-1) Update your ingress parameters as noted [here](#ingress-parameters).
-
-2) Update values.yaml with the following changes:
-
-```
-nifikop:
-  disabled: &nifikopDisabled true
-  enabled: &nifikopEnabled false
-```
-
-**NOTE:** Due to a limitation in Helm, when using the Health Patterns chart with a release name other than the defaults of `ingestion`, you are required to update the clinical_ingestion.yaml file to correspond to the correct release name.
-
-```
-nifi:
-  extraContainers:
-    - name: post-start-setup
-      env:
-      - name: "RELEASE_NAME"
-        value: "ingest"
-```
-
 Finally, to deploy run:
 
 `helm install ingestion . -f clinical_ingestion.yaml`
@@ -243,6 +214,37 @@ By default, the Ingestion pattern will also deploy the Enrichment pipeline.  It 
 
 ## Advanced topics
 
+
+#### Alternative deployment instructions (insecure)
+
+The instructions listed above are the recommended steps for deploying Health Patterns Ingestion flow. However, it requires sufficient authority to the target cluster to deploy Custom Resource Definitions and configure an OIDC service. If these authorities are not attainable it may be necessary to deploy an unsecured, non-authenticating version of Ingestion.
+
+**NOTE:** Given the significant differences between the Nifikop-based deployment and this, it is not feasible to maintain both approaches targeting current Nifi dataflows. Therefore, using the insecure deployment will result in a snapshot of these flows current as of November 2021, but not updated since.
+
+First, setup deployment parameters:
+
+1) Update your ingress parameters as noted [here](#ingress-parameters).
+
+2) Update values.yaml with the following changes:
+
+```
+nifikop:
+  disabled: &nifikopDisabled true
+  enabled: &nifikopEnabled false
+```
+
+**NOTE:** Due to a limitation in Helm, when using the Health Patterns chart with a release name other than the defaults of `ingestion`, you are required to update the clinical_ingestion.yaml file to correspond to the correct release name.
+
+```
+nifi:
+  extraContainers:
+    - name: post-start-setup
+      env:
+      - name: "RELEASE_NAME"
+        value: "ingest"
+```
+
+
 #### FHIR Server configuration
 This pattern relies on a FHIR server for data persistence and retrieval.  It provides a basic configuration for the server but there are a number of advanced options that can be added or modified (for example, which backend database is used-Derby, DB2, PostgreSQL, etc.).  We suggest you consult the [FHIR documentation](https://github.com/ibm/fhir) for those options.
 
@@ -270,27 +272,15 @@ and
 --set fhir-deid.proxy.enabled=true
 ```
 
-#### Alternate configuration for Helm Chart
+
+
+#### Advanced configuration for Helm Chart
 
 When deploying this chart, there are many configuration parameters specified in the values.yaml file.  These can all be overridden based on individual preferences.  To do so, you can create a secondary YAML file containing your changes and specify it to the `helm install` command to override default configuration.
 
-```
-helm install <<RELEASE_NAME>> . \
-    -f value_overrides.yaml \
-    -f clinical_ingestion.yaml
-```
+`helm install ingestion . -f value_overrides.yaml`
 
 **NOTE:** You can chain multiple override file parameters in yaml, so if you want to deploy the load balancer values as well as other overrides, just specify each using another "-f" parameter.
-
-**NOTE:** Due to a limitation in Helm, when using the Health Patterns chart with a release name other than the defaults of `ingestion`, you are required to update the corresponding yaml file to have to the correct release name.  
-
-For ingestion, update the `RELEASE_NAME` environment variable in the `clinical_ingestion.yaml` file.  The value _ingestion_ should be changed to whatever release name you choose.
-
-```
-env:
-- name: "RELEASE_NAME"
-  value: "ingestion"
-```
 
 #### Kafka topics for the pipeline
 


### PR DESCRIPTION
Update the documentation to describe how to deploy nifi via Nifikop as the "default" option.  Move the insecure (obsolete) approach to a backup option (not recommended). 