### PR TITLE
Atc update chart dependency versions

### DIFF
--- a/helm-charts/health-patterns/Chart.yaml
+++ b/helm-charts/health-patterns/Chart.yaml
@@ -83,26 +83,20 @@ dependencies:
     version: 0.1.0
     condition: ascvd.enabled
     repository: https://alvearie.github.io/health-analytics/charts
+  - name: zookeeper
+    version: 7.6.0
+    condition: zookeeper.enabled
+    repository: https://charts.bitnami.com/bitnami
 
 # Old Nifi
-  - name: zookeeper
-    version: 6.0.0
-    condition: nifikop.disabled, zookeeper.enabled
-    repository: https://charts.bitnami.com/bitnami
   - name: nifi
-    version: 0.6.0
+    version: 1.0.4
     condition: nifikop.disabled, nifi.enabled
     repository: https://cetic.github.io/helm-charts
 
 # New Nifi via NifiKop
-  - name: zookeeper
-    alias: zookeeper2
-    version: 7.4.5
-    condition: nifikop.enabled, zookeeper2.enabled
-    repository: https://charts.bitnami.com/bitnami
-
   - name: kafka
-    version: 12.1.0
+    version: 14.8.1
     condition: kafka.enabled
     repository: https://charts.bitnami.com/bitnami
   - name: expose-kafka

--- a/helm-charts/health-patterns/values.yaml
+++ b/helm-charts/health-patterns/values.yaml
@@ -265,12 +265,7 @@ cert-secret-generator:
 # Zookeeper Configuration
 # ------------------------------------------------------------------------------
 zookeeper:
-  enabled: *nifikopDisabled
-  # The zookeeper fullname is overridden so that the same instance deployed here by default can be referred to by both NiFi and Kafka
-  fullnameOverride: alvearie-zookeeper
-
-zookeeper2:
-  enabled: *nifikopEnabled
+  enabled: true
   # The zookeeper fullname is overridden so that the same instance deployed here by default can be referred to by both NiFi and Kafka
   fullnameOverride: alvearie-zookeeper
 
@@ -283,7 +278,7 @@ nifi2: # NifiKop based Nifi
   fullnameOverride: alvearie-nifi
   image:
     repository: apache/nifi
-    tag: 1.12.1
+    tag: 1.13.2
   user: *oidc_users
   oidc:
     discovery:
@@ -318,6 +313,8 @@ nifi2: # NifiKop based Nifi
 # Nifi Configuration
 # ------------------------------------------------------------------------------
 nifi:
+  image:
+    tag: 1.13.2
   fullnameOverride: alvearie-nifi
   enabled: *nifikopDisabled
   ingress:
@@ -362,6 +359,7 @@ nifi:
     - name: alvearie-nars
       emptyDir: {}
   properties:
+    externalSecure: true
     customLibPath: ./custom-nars
   logresources:
     requests:

--- a/helm-charts/health-patterns/values.yaml
+++ b/helm-charts/health-patterns/values.yaml
@@ -359,7 +359,6 @@ nifi:
     - name: alvearie-nars
       emptyDir: {}
   properties:
-    externalSecure: true
     customLibPath: ./custom-nars
   logresources:
     requests:


### PR DESCRIPTION
This updates Kafka, Zookeeper, and Nifi to newer versions. This will avoid the Log4J problem in Kafka and Zookeeper, but not Nifi. Nifi requires 1.15.2, and right now we're blocked at 1.13. Working to move to 1.15.2+ in a separate change.